### PR TITLE
chore(lyra): small refactor of variable check

### DIFF
--- a/packages/lyra/src/prefix-tree/trie.ts
+++ b/packages/lyra/src/prefix-tree/trie.ts
@@ -86,13 +86,12 @@ export class Trie {
     if (!word) return false;
 
     function removeWord(node: TrieNode, _word: string, docID: string): boolean {
-      const [nodeWord, _docs] = node.getWord();
+      const [nodeWord /**_docs*/] = node.getWord();
 
       if (node.end && nodeWord === word) {
-        const hasChildren = node.children?.size ?? 0 > 0;
         node.removeDoc(docID);
 
-        if (hasChildren) {
+        if (node.children?.size) {
           node.end = false;
         }
 
@@ -117,9 +116,7 @@ export class Trie {
 
     function removeWord(node: TrieNode, _word: string): boolean {
       if (node.end && node.getWord()[0] === word) {
-        const hasChildren = node.children?.size ?? 0 > 0;
-
-        if (hasChildren) {
+        if (node.children?.size) {
           node.end = false;
         } else {
           node.parent!.deleteChildren();


### PR DESCRIPTION
I was reading through the code, I really loved this one, and it got me wondering if it is something I'm not getting or if we could just skip a condition and run the check against the returned Map size.

I take this opportunity to tell that I think the ./package.json -> benchmark script contains an outdated path to benchmarks after the build pipeline.
