### PR TITLE
Implemented typo tolerance 

### DIFF
--- a/packages/lyra/src/lyra.ts
+++ b/packages/lyra/src/lyra.ts
@@ -185,7 +185,7 @@ export class Lyra {
     params: SearchParams & { index: string }
   ): Promise<Set<string>> {
     const idx = this.index.get(params.index);
-    const searchResult = idx?.find(params.term, params.fixTypos ?? true);
+    const searchResult = idx?.find(params.term, params.fixTypos);
     const ids = new Set<string>();
 
     for (const key in searchResult) {

--- a/packages/lyra/src/lyra.ts
+++ b/packages/lyra/src/lyra.ts
@@ -25,6 +25,7 @@ export type SearchParams = {
   properties?: "*" | string[];
   limit?: number;
   offset?: number;
+  fixTypos?: boolean;
 };
 
 type LyraIndex = Map<string, Trie>;
@@ -184,7 +185,7 @@ export class Lyra {
     params: SearchParams & { index: string }
   ): Promise<Set<string>> {
     const idx = this.index.get(params.index);
-    const searchResult = idx?.find(params.term);
+    const searchResult = idx?.find(params.term, params.fixTypos ?? true);
     const ids = new Set<string>();
 
     for (const key in searchResult) {


### PR DESCRIPTION
This implements typo tolerance (#2) with a recursive algorithm that allows 1 typo (mistype character o extra character in search term).
Currently the algorithms doesn't work correctly in 100% of cases because of the stemming.

Since the stemming simply maps each word to the relative stem, words that are not in the map will not be stemmed at all. So let's say we want to search the word `luckiest` but we write `luckiext`: the former will be stemmed to `luck` while the latter won't be stemmed at all (because it is not a key in the stemming map), so the algorithm counts 4 typos (i.e. `i`, `e`, `x`, `t`) and doesn't return the correct result.

A possible solution could to remove the stemming since it is an optional step. 
