### PR TITLE
bug: default search will perform with default language - language can be specified allowing multi-lingual search

### DIFF
--- a/packages/lyra/src/lyra.ts
+++ b/packages/lyra/src/lyra.ts
@@ -81,8 +81,8 @@ export class Lyra {
     }
   }
 
-  async search(params: SearchParams): SearchResult {
-    const tokens = tokenize(params.term).values();
+  async search(params: SearchParams, language: Language = this.defaultLanguage): SearchResult {
+    const tokens = tokenize(params.term, language).values();
     const indices = this.getIndices(params.properties);
     const { limit = 10, offset = 0 } = params;
     const results: object[] = new Array({ length: limit });


### PR DESCRIPTION
closes: #6

The intended change is to be 100% backward compatible, moving the default argument into the `search` function of the index Class.

It copies the pattern used in the insert statement - and should give a more logical default behavior to searching with non-English default languages.

Thanks :pray: 