### PR TITLE
Exact match

### DIFF
--- a/packages/lyra/src/lyra.ts
+++ b/packages/lyra/src/lyra.ts
@@ -190,7 +190,7 @@ export class Lyra {
   ): Promise<Set<string>> {
     const idx = this.index.get(params.index);
     const searchResult = idx?.find({
-      prefix: params.term,
+      term: params.term,
       exact: params.exact,
     });
     const ids = new Set<string>();

--- a/packages/lyra/src/lyra.ts
+++ b/packages/lyra/src/lyra.ts
@@ -25,7 +25,7 @@ export type SearchParams = {
   properties?: "*" | string[];
   limit?: number;
   offset?: number;
-  exact?: boolean | undefined;
+  exact?: boolean;
 };
 
 type LyraIndex = Map<string, Trie>;

--- a/packages/lyra/src/prefix-tree/trie.ts
+++ b/packages/lyra/src/prefix-tree/trie.ts
@@ -1,5 +1,10 @@
 import { TrieNode } from "./node";
 
+export type FindParams = {
+  prefix: string;
+  exact?: boolean;
+};
+
 export type FindResult = {
   [key: string]: Set<string>;
 };
@@ -44,7 +49,7 @@ export class Trie {
     return node.end;
   }
 
-  find(prefix: string): FindResult {
+  find({ prefix, exact }: FindParams): FindResult {
     let node = this.root;
     const output: FindResult = {};
 
@@ -61,6 +66,10 @@ export class Trie {
     function findAllWords(_node: TrieNode, _output: FindResult) {
       if (_node.end) {
         const [word, docIDs] = _node.getWord();
+
+        if (exact && word !== prefix) {
+          return output;
+        }
 
         if (!(word in _output)) {
           _output[word] = new Set();

--- a/packages/lyra/src/prefix-tree/trie.ts
+++ b/packages/lyra/src/prefix-tree/trie.ts
@@ -1,7 +1,7 @@
 import { TrieNode } from "./node";
 
 export type FindParams = {
-  prefix: string;
+  term: string;
   exact?: boolean;
 };
 
@@ -49,11 +49,11 @@ export class Trie {
     return node.end;
   }
 
-  find({ prefix, exact }: FindParams): FindResult {
+  find({ term, exact }: FindParams): FindResult {
     let node = this.root;
     const output: FindResult = {};
 
-    for (const char of prefix) {
+    for (const char of term) {
       if (node?.children?.has(char)) {
         node = node.children.get(char)!;
       } else {
@@ -67,7 +67,7 @@ export class Trie {
       if (_node.end) {
         const [word, docIDs] = _node.getWord();
 
-        if (exact && word !== prefix) {
+        if (exact && word !== term) {
           return output;
         }
 

--- a/packages/lyra/tests/lyra.test.ts
+++ b/packages/lyra/tests/lyra.test.ts
@@ -273,4 +273,36 @@ describe("lyra", () => {
     expect(search.count).toBe(1);
     expect((search.hits[0] as any).author).toBe("Frank Zappa");
   });
+
+  it("Should exact match", async () => {
+    const db = new Lyra({
+      schema: {
+        author: "string",
+        quote: "string",
+      },
+    });
+
+    await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+    });
+
+    const partialSearch = await db.search({
+      term: "alr",
+      exact: true,
+    });
+
+    expect(partialSearch.count).toBe(0);
+
+    const exactSearch = await db.search({
+      term: "already",
+      exact: true,
+    });
+
+    expect(exactSearch.count).toBe(1);
+    expect((exactSearch.hits[0] as any).quote).toBe(
+      "Be yourself; everyone else is already taken."
+    );
+    expect((exactSearch.hits[0] as any).author).toBe("Oscar Wilde");
+  });
 });

--- a/packages/lyra/tests/trie.test.ts
+++ b/packages/lyra/tests/trie.test.ts
@@ -30,10 +30,10 @@ describe("trie", () => {
       trie.insert(doc, id);
     }
 
-    expect(trie.find(phrases[5].doc.slice(0, 5))).toStrictEqual({
+    expect(trie.find({ prefix: phrases[5].doc.slice(0, 5) })).toStrictEqual({
       [phrases[5].doc]: new Set(phrases[5].id),
     });
-    expect(trie.find("th")).toMatchInlineSnapshot(`
+    expect(trie.find({ prefix: "th" })).toMatchInlineSnapshot(`
       Object {
         "the quick, brown fox": Set {
           "1",
@@ -61,6 +61,6 @@ describe("trie", () => {
     trie.remove(phrases[0].doc);
 
     expect(trie.contains(phrases[0].doc)).toBeFalsy();
-    expect(trie.find(phrases[0].doc)).toStrictEqual({});
+    expect(trie.find({ prefix: phrases[0].doc })).toStrictEqual({});
   });
 });

--- a/packages/lyra/tests/trie.test.ts
+++ b/packages/lyra/tests/trie.test.ts
@@ -30,10 +30,10 @@ describe("trie", () => {
       trie.insert(doc, id);
     }
 
-    expect(trie.find({ prefix: phrases[5].doc.slice(0, 5) })).toStrictEqual({
+    expect(trie.find({ term: phrases[5].doc.slice(0, 5) })).toStrictEqual({
       [phrases[5].doc]: new Set(phrases[5].id),
     });
-    expect(trie.find({ prefix: "th" })).toMatchInlineSnapshot(`
+    expect(trie.find({ term: "th" })).toMatchInlineSnapshot(`
       Object {
         "the quick, brown fox": Set {
           "1",
@@ -61,6 +61,6 @@ describe("trie", () => {
     trie.remove(phrases[0].doc);
 
     expect(trie.contains(phrases[0].doc)).toBeFalsy();
-    expect(trie.find({ prefix: phrases[0].doc })).toStrictEqual({});
+    expect(trie.find({ term: phrases[0].doc })).toStrictEqual({});
   });
 });


### PR DESCRIPTION
This PR implements the #1 using a parameter that determinates if the search actions requires an exact match or not.

The `find` method of Trie nodes now accept an object as a single parameter. The type has been added: `FindParams`.

The solution found is to insert a check in the recursive function `findAllWords`, if the search actions requires an **exact** match and the _word_ given by the last node doesn't match with the _prefix_, returns the initial output.

I wrote the tests for this, I'm considering add more tests if necessary.