### PR TITLE
Utils test

### DIFF
--- a/packages/lyra/tests/utils.test.ts
+++ b/packages/lyra/tests/utils.test.ts
@@ -1,8 +1,4 @@
-import {
-  formatBytes,
-  formatNanoseconds,
-  getNanosecondsTime,
-} from "../src/utils";
+import { formatBytes, formatNanoseconds } from "../src/utils";
 
 describe("utils", () => {
   it("should correctly format bytes", async () => {

--- a/packages/lyra/tests/utils.test.ts
+++ b/packages/lyra/tests/utils.test.ts
@@ -1,0 +1,26 @@
+import {
+  formatBytes,
+  formatNanoseconds,
+  getNanosecondsTime,
+} from "../src/utils";
+
+describe("utils", () => {
+  it("should correctly format bytes", async () => {
+    expect(formatBytes(0)).toBe("0 Bytes");
+    expect(formatBytes(1)).toBe("1 Bytes");
+    expect(formatBytes(1024)).toBe("1 KB");
+    expect(formatBytes(1024 ** 2)).toBe("1 MB");
+    expect(formatBytes(1024 ** 3)).toBe("1 GB");
+    expect(formatBytes(1024 ** 4)).toBe("1 TB");
+    expect(formatBytes(1024 ** 5)).toBe("1 PB");
+    expect(formatBytes(1024 ** 6)).toBe("1 EB");
+    expect(formatBytes(1024 ** 7)).toBe("1 ZB");
+  });
+
+  it("should correctly format nanoseconds", async () => {
+    expect(formatNanoseconds(1_000_000n)).toBe("1ms");
+    expect(formatNanoseconds(1_000_000_000n)).toBe("1000ms"); // 1s
+    expect(formatNanoseconds(1_000_000_000_000n)).toBe("1000000ms"); // 1m
+    expect(formatNanoseconds(1_000_000_000_000_000n)).toBe("1000000000ms"); // 1h
+  });
+});


### PR DESCRIPTION
This PR includes the tests for **Utils** module.

The tested methods are:
- formatBytes
- formatNanoseconds

The current coverage for the utils is:

| File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
| --------- | ------- | -------- | ------- | ------- | ----------------- |
| All files | 82.57   | 61.53    | 86.84   | 82.67   |                   |
| utils.ts  | 52.63   | 33.33    | 66.66   | 52.63   | 4-11,22,30        |

After the tests:

| File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
| --------- | ------- | -------- | ------- | ------- | ----------------- |
| All files | 85.49   | 63.51    | 89.47   | 85.71   |                   |
| utils.ts  | 94.73   | 83.33    | 100     | 94.73   | 30                |

