### PR TITLE
fix(benchmark start command): bennchmark start command and files import

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest --coverage",
     "lint": "prettier --write \"packages/**/*.{ts,js}\" && eslint . --ext .js,.ts",
     "prepare": "husky install",
-    "benchmark": "pnpm build:lyra && ts-node ./packages/benchmark/benchmark.ts",
+    "benchmark": "pnpm build:lyra && node ./packages/benchmarks/index.js",
     "build:lyra": "cd packages/lyra && pnpm build"
   },
   "keywords": [],

--- a/packages/benchmarks/engines/prefix-search-movies.js
+++ b/packages/benchmarks/engines/prefix-search-movies.js
@@ -64,3 +64,5 @@ const testCases = {
 };
 
 cronometro(testCases);
+
+export default testCases;

--- a/packages/benchmarks/index.js
+++ b/packages/benchmarks/index.js
@@ -1,7 +1,7 @@
 import cronometro from "cronometro";
-import prefixSearch from "./engines/prefix-search";
-import prefixSearchMovies from "./engines/prefix-search-movies";
-import indexing from "./engines/indexing";
+import prefixSearch from "./engines/prefix-search.js";
+import prefixSearchMovies from "./engines/prefix-search-movies.js";
+import indexing from "./engines/indexing.js";
 
 cronometro(prefixSearch);
 cronometro(indexing);


### PR DESCRIPTION
With this PR I would like to improve the benchmark package, that currently isn't working.

Even after this, the `title.csv` required by `prefix-search-movies` is still missing.