### PR TITLE
Typed Lyra.insert method according to the schema used

### DIFF
--- a/packages/lyra/src/lyra.ts
+++ b/packages/lyra/src/lyra.ts
@@ -11,280 +11,280 @@ import type { ResolveSchema } from "./types";
 export type PropertyType = "string" | "number" | "boolean";
 
 export type PropertiesSchema = {
-	[key: string]: PropertyType | PropertiesSchema;
+  [key: string]: PropertyType | PropertiesSchema;
 };
 
 export type LyraProperties<
-	TSchema extends PropertiesSchema = PropertiesSchema
+  TSchema extends PropertiesSchema = PropertiesSchema
 > = {
-	schema: TSchema;
-	defaultLanguage?: Language;
+  schema: TSchema;
+  defaultLanguage?: Language;
 };
 
 export type LyraDocs = Map<string, object>;
 
 export type SearchParams = {
-	term: string;
-	properties?: "*" | string[];
-	limit?: number;
-	offset?: number;
-	exact?: boolean;
-	tolerance?: number;
+  term: string;
+  properties?: "*" | string[];
+  limit?: number;
+  offset?: number;
+  exact?: boolean;
+  tolerance?: number;
 };
 
 type LyraIndex = Map<string, Trie>;
 
 type QueueDocParams = {
-	id: string;
-	doc: object;
-	language: Language;
+  id: string;
+  doc: object;
+  language: Language;
 };
 
 type SearchResult = Promise<{
-	count: number;
-	hits: object[];
-	elapsed: string;
+  count: number;
+  hits: object[];
+  elapsed: string;
 }>;
 
 export class Lyra<TSchema extends PropertiesSchema = PropertiesSchema> {
-	private defaultLanguage: Language = "english";
-	private schema: TSchema;
-	private docs: LyraDocs = new Map();
-	private index: LyraIndex = new Map();
+  private defaultLanguage: Language = "english";
+  private schema: TSchema;
+  private docs: LyraDocs = new Map();
+  private index: LyraIndex = new Map();
 
-	private queue: queueAsPromised<QueueDocParams> = fastq.promise(
-		this,
-		this._insert,
-		1
-	);
+  private queue: queueAsPromised<QueueDocParams> = fastq.promise(
+    this,
+    this._insert,
+    1
+  );
 
-	constructor(properties: LyraProperties<TSchema>) {
-		const defaultLanguage =
-			(properties?.defaultLanguage?.toLowerCase() as Language) ?? "english";
+  constructor(properties: LyraProperties<TSchema>) {
+    const defaultLanguage =
+      (properties?.defaultLanguage?.toLowerCase() as Language) ?? "english";
 
-		if (!SUPPORTED_LANGUAGES.includes(defaultLanguage)) {
-			throw ERRORS.LANGUAGE_NOT_SUPPORTED(defaultLanguage);
-		}
+    if (!SUPPORTED_LANGUAGES.includes(defaultLanguage)) {
+      throw ERRORS.LANGUAGE_NOT_SUPPORTED(defaultLanguage);
+    }
 
-		this.defaultLanguage = defaultLanguage;
-		this.schema = properties.schema;
-		this.buildIndex(properties.schema);
-	}
+    this.defaultLanguage = defaultLanguage;
+    this.schema = properties.schema;
+    this.buildIndex(properties.schema);
+  }
 
-	private buildIndex(schema: TSchema, prefix = "") {
-		for (const prop of Object.keys(schema)) {
-			const propType = typeof prop;
-			const isNested = typeof schema[prop] === "object";
+  private buildIndex(schema: TSchema, prefix = "") {
+    for (const prop of Object.keys(schema)) {
+      const propType = typeof prop;
+      const isNested = typeof schema[prop] === "object";
 
-			if (propType !== "string") throw ERRORS.INVALID_SCHEMA_TYPE(propType);
+      if (propType !== "string") throw ERRORS.INVALID_SCHEMA_TYPE(propType);
 
-			const propName = `${prefix}${prop}`;
+      const propName = `${prefix}${prop}`;
 
-			if (isNested) {
-				this.buildIndex(schema[prop] as TSchema, `${propName}.`);
-			} else {
-				this.index.set(propName, new Trie());
-			}
-		}
-	}
+      if (isNested) {
+        this.buildIndex(schema[prop] as TSchema, `${propName}.`);
+      } else {
+        this.index.set(propName, new Trie());
+      }
+    }
+  }
 
-	async search(
-		params: SearchParams,
-		language: Language = this.defaultLanguage
-	): SearchResult {
-		const tokens = tokenize(params.term, language).values();
-		const indices = this.getIndices(params.properties);
-		const { limit = 10, offset = 0, exact = false } = params;
-		const results: object[] = new Array({ length: limit });
-		let totalResults = 0;
+  async search(
+    params: SearchParams,
+    language: Language = this.defaultLanguage
+  ): SearchResult {
+    const tokens = tokenize(params.term, language).values();
+    const indices = this.getIndices(params.properties);
+    const { limit = 10, offset = 0, exact = false } = params;
+    const results: object[] = new Array({ length: limit });
+    let totalResults = 0;
 
-		const timeStart = getNanosecondsTime();
+    const timeStart = getNanosecondsTime();
 
-		let i = 0;
-		let j = 0;
+    let i = 0;
+    let j = 0;
 
-		for (const token of tokens) {
-			for (const index of indices) {
-				const documentIDs = await this.getDocumentIDsFromSearch({
-					...params,
-					index: index,
-					term: token,
-					exact: exact,
-				});
+    for (const token of tokens) {
+      for (const index of indices) {
+        const documentIDs = await this.getDocumentIDsFromSearch({
+          ...params,
+          index: index,
+          term: token,
+          exact: exact,
+        });
 
-				totalResults += documentIDs.size;
+        totalResults += documentIDs.size;
 
-				if (i >= limit) {
-					break;
-				}
+        if (i >= limit) {
+          break;
+        }
 
-				if (documentIDs.size) {
-					for (const id of documentIDs) {
-						if (j < offset) {
-							j++;
-							continue;
-						}
+        if (documentIDs.size) {
+          for (const id of documentIDs) {
+            if (j < offset) {
+              j++;
+              continue;
+            }
 
-						if (i >= limit) {
-							break;
-						}
+            if (i >= limit) {
+              break;
+            }
 
-						const fullDoc = this.docs.get(id);
-						results[i] = { id, ...fullDoc };
-						i++;
-					}
-				}
-			}
-		}
+            const fullDoc = this.docs.get(id);
+            results[i] = { id, ...fullDoc };
+            i++;
+          }
+        }
+      }
+    }
 
-		return {
-			elapsed: formatNanoseconds(getNanosecondsTime() - timeStart),
-			hits: results,
-			count: totalResults,
-		};
-	}
+    return {
+      elapsed: formatNanoseconds(getNanosecondsTime() - timeStart),
+      hits: results,
+      count: totalResults,
+    };
+  }
 
-	private getIndices(indices: SearchParams["properties"]): string[] {
-		const knownIndices = [...this.index.keys()];
+  private getIndices(indices: SearchParams["properties"]): string[] {
+    const knownIndices = [...this.index.keys()];
 
-		if (!indices) {
-			return knownIndices;
-		}
+    if (!indices) {
+      return knownIndices;
+    }
 
-		if (typeof indices === "string") {
-			if (indices === "*") {
-				return knownIndices;
-			} else {
-				throw ERRORS.INVALID_PROPERTY(indices, knownIndices);
-			}
-		}
+    if (typeof indices === "string") {
+      if (indices === "*") {
+        return knownIndices;
+      } else {
+        throw ERRORS.INVALID_PROPERTY(indices, knownIndices);
+      }
+    }
 
-		for (const index of indices as string[]) {
-			if (!knownIndices.includes(index)) {
-				throw ERRORS.INVALID_PROPERTY(index, knownIndices);
-			}
-		}
+    for (const index of indices as string[]) {
+      if (!knownIndices.includes(index)) {
+        throw ERRORS.INVALID_PROPERTY(index, knownIndices);
+      }
+    }
 
-		return indices as string[];
-	}
+    return indices as string[];
+  }
 
-	async delete(docID: string): Promise<boolean> {
-		if (!this.docs.has(docID)) {
-			throw ERRORS.DOC_ID_DOES_NOT_EXISTS(docID);
-		}
+  async delete(docID: string): Promise<boolean> {
+    if (!this.docs.has(docID)) {
+      throw ERRORS.DOC_ID_DOES_NOT_EXISTS(docID);
+    }
 
-		const document = this.docs.get(docID)!;
+    const document = this.docs.get(docID)!;
 
-		for (const key in document) {
-			const idx = this.index.get(key)!;
-			const tokens = tokenize((document as any)[key]);
+    for (const key in document) {
+      const idx = this.index.get(key)!;
+      const tokens = tokenize((document as any)[key]);
 
-			for (const token of tokens) {
-				if (idx.removeDocByWord(token, docID)) {
-					throw `Unable to remove document "${docID}" from index "${key}" on word "${token}".`;
-				}
-			}
-		}
+      for (const token of tokens) {
+        if (idx.removeDocByWord(token, docID)) {
+          throw `Unable to remove document "${docID}" from index "${key}" on word "${token}".`;
+        }
+      }
+    }
 
-		this.docs.delete(docID);
+    this.docs.delete(docID);
 
-		return true;
-	}
+    return true;
+  }
 
-	private async getDocumentIDsFromSearch(
-		params: SearchParams & { index: string }
-	): Promise<Set<string>> {
-		const idx = this.index.get(params.index);
-		const searchResult = idx?.find({
-			term: params.term,
-			exact: params.exact,
-			tolerance: params.tolerance,
-		});
-		const ids = new Set<string>();
+  private async getDocumentIDsFromSearch(
+    params: SearchParams & { index: string }
+  ): Promise<Set<string>> {
+    const idx = this.index.get(params.index);
+    const searchResult = idx?.find({
+      term: params.term,
+      exact: params.exact,
+      tolerance: params.tolerance,
+    });
+    const ids = new Set<string>();
 
-		for (const key in searchResult) {
-			for (const id of (searchResult as any)[key]) {
-				ids.add(id);
-			}
-		}
-		return ids;
-	}
+    for (const key in searchResult) {
+      for (const id of (searchResult as any)[key]) {
+        ids.add(id);
+      }
+    }
+    return ids;
+  }
 
-	public async insert(
-		doc: ResolveSchema<TSchema>,
-		language: Language = this.defaultLanguage
-	): Promise<{ id: string }> {
-		const id = nanoid();
+  public async insert(
+    doc: ResolveSchema<TSchema>,
+    language: Language = this.defaultLanguage
+  ): Promise<{ id: string }> {
+    const id = nanoid();
 
-		if (!SUPPORTED_LANGUAGES.includes(language)) {
-			throw ERRORS.LANGUAGE_NOT_SUPPORTED(language);
-		}
+    if (!SUPPORTED_LANGUAGES.includes(language)) {
+      throw ERRORS.LANGUAGE_NOT_SUPPORTED(language);
+    }
 
-		if (!(await this.checkInsertDocSchema(doc))) {
-			throw ERRORS.INVALID_DOC_SCHEMA(this.schema, doc);
-		}
+    if (!(await this.checkInsertDocSchema(doc))) {
+      throw ERRORS.INVALID_DOC_SCHEMA(this.schema, doc);
+    }
 
-		await this.queue.push({
-			id,
-			doc,
-			language,
-		});
+    await this.queue.push({
+      id,
+      doc,
+      language,
+    });
 
-		return { id };
-	}
+    return { id };
+  }
 
-	private async _insert({ doc, id, language }: QueueDocParams): Promise<void> {
-		const index = this.index;
-		this.docs.set(id, doc);
+  private async _insert({ doc, id, language }: QueueDocParams): Promise<void> {
+    const index = this.index;
+    this.docs.set(id, doc);
 
-		function recursiveTrieInsertion(doc: object, prefix = "") {
-			for (const key in doc) {
-				const isNested = typeof (doc as any)[key] === "object";
-				const propName = `${prefix}${key}`;
-				if (isNested) {
-					recursiveTrieInsertion((doc as any)[key], `${propName}.`);
-				} else if (typeof (doc as any)[key] === "string") {
-					// Use propName here because if doc is a nested object
-					// We will get the wrong index
-					const requestedTrie = index.get(propName);
-					const tokens = tokenize((doc as any)[key], language);
+    function recursiveTrieInsertion(doc: object, prefix = "") {
+      for (const key in doc) {
+        const isNested = typeof (doc as any)[key] === "object";
+        const propName = `${prefix}${key}`;
+        if (isNested) {
+          recursiveTrieInsertion((doc as any)[key], `${propName}.`);
+        } else if (typeof (doc as any)[key] === "string") {
+          // Use propName here because if doc is a nested object
+          // We will get the wrong index
+          const requestedTrie = index.get(propName);
+          const tokens = tokenize((doc as any)[key], language);
 
-					for (const token of tokens) {
-						requestedTrie?.insert(token, id);
-					}
-				}
-			}
-		}
+          for (const token of tokens) {
+            requestedTrie?.insert(token, id);
+          }
+        }
+      }
+    }
 
-		recursiveTrieInsertion(doc);
-	}
+    recursiveTrieInsertion(doc);
+  }
 
-	private async checkInsertDocSchema(
-		doc: QueueDocParams["doc"]
-	): Promise<boolean> {
-		function recursiveCheck(
-			newDoc: QueueDocParams["doc"],
-			schema: PropertiesSchema
-		): boolean {
-			for (const key in newDoc) {
-				if (!(key in schema)) {
-					return false;
-				}
+  private async checkInsertDocSchema(
+    doc: QueueDocParams["doc"]
+  ): Promise<boolean> {
+    function recursiveCheck(
+      newDoc: QueueDocParams["doc"],
+      schema: PropertiesSchema
+    ): boolean {
+      for (const key in newDoc) {
+        if (!(key in schema)) {
+          return false;
+        }
 
-				const propType = typeof (newDoc as any)[key];
+        const propType = typeof (newDoc as any)[key];
 
-				if (propType === "object") {
-					recursiveCheck((newDoc as any)[key], schema);
-				} else {
-					if (typeof (newDoc as any)[key] !== schema[key]) {
-						return false;
-					}
-				}
-			}
+        if (propType === "object") {
+          recursiveCheck((newDoc as any)[key], schema);
+        } else {
+          if (typeof (newDoc as any)[key] !== schema[key]) {
+            return false;
+          }
+        }
+      }
 
-			return true;
-		}
+      return true;
+    }
 
-		return recursiveCheck(doc, this.schema);
-	}
+    return recursiveCheck(doc, this.schema);
+  }
 }

--- a/packages/lyra/src/lyra.ts
+++ b/packages/lyra/src/lyra.ts
@@ -10,274 +10,277 @@ import { Language, SUPPORTED_LANGUAGES } from "./stemmer";
 export type PropertyType = "string" | "number" | "boolean";
 
 export type PropertiesSchema = {
-  [key: string]: PropertyType | PropertiesSchema;
+	[key: string]: PropertyType | PropertiesSchema;
 };
 
 export type LyraProperties = {
-  schema: PropertiesSchema;
-  defaultLanguage?: Language;
+	schema: PropertiesSchema;
+	defaultLanguage?: Language;
 };
 
 export type LyraDocs = Map<string, object>;
 
 export type SearchParams = {
-  term: string;
-  properties?: "*" | string[];
-  limit?: number;
-  offset?: number;
-  exact?: boolean;
-  tolerance?: number;
+	term: string;
+	properties?: "*" | string[];
+	limit?: number;
+	offset?: number;
+	exact?: boolean;
+	tolerance?: number;
 };
 
 type LyraIndex = Map<string, Trie>;
 
 type QueueDocParams = {
-  id: string;
-  doc: object;
-  language: Language;
+	id: string;
+	doc: object;
+	language: Language;
 };
 
 type SearchResult = Promise<{
-  count: number;
-  hits: object[];
-  elapsed: string;
+	count: number;
+	hits: object[];
+	elapsed: string;
 }>;
 
 export class Lyra {
-  private defaultLanguage: Language = "english";
-  private schema: PropertiesSchema;
-  private docs: LyraDocs = new Map();
-  private index: LyraIndex = new Map();
-  private queue: queueAsPromised<QueueDocParams> = fastq.promise(
-    this,
-    this._insert,
-    1
-  );
+	private defaultLanguage: Language = "english";
+	private schema: PropertiesSchema;
+	private docs: LyraDocs = new Map();
+	private index: LyraIndex = new Map();
+	private queue: queueAsPromised<QueueDocParams> = fastq.promise(
+		this,
+		this._insert,
+		1
+	);
 
-  constructor(properties: LyraProperties) {
-    const defaultLanguage =
-      (properties?.defaultLanguage?.toLowerCase() as Language) ?? "english";
+	constructor(properties: LyraProperties) {
+		const defaultLanguage =
+			(properties?.defaultLanguage?.toLowerCase() as Language) ?? "english";
 
-    if (!SUPPORTED_LANGUAGES.includes(defaultLanguage)) {
-      throw ERRORS.LANGUAGE_NOT_SUPPORTED(defaultLanguage);
-    }
+		if (!SUPPORTED_LANGUAGES.includes(defaultLanguage)) {
+			throw ERRORS.LANGUAGE_NOT_SUPPORTED(defaultLanguage);
+		}
 
-    this.defaultLanguage = defaultLanguage;
-    this.schema = properties.schema;
-    this.buildIndex(properties.schema);
-  }
+		this.defaultLanguage = defaultLanguage;
+		this.schema = properties.schema;
+		this.buildIndex(properties.schema);
+	}
 
-  private buildIndex(schema: PropertiesSchema) {
-    for (const prop in schema) {
-      const propType = typeof prop;
+	private buildIndex(schema: PropertiesSchema, prefix = "") {
+		for (const prop in schema) {
+			const propType = typeof prop;
+			const isNested = typeof schema[prop] === "object";
 
-      if (propType === "string") {
-        this.index.set(prop, new Trie());
-      } else if (propType === "object") {
-        // @todo nested properties will be supported with the next versions
-        //this.buildIndex(prop as unknown as PropertiesSchema);
-        throw ERRORS.UNSUPPORTED_NESTED_PROPERTIES();
-      } else {
-        throw ERRORS.INVALID_SCHEMA_TYPE(propType);
-      }
-    }
-  }
+			if (propType !== "string") throw ERRORS.INVALID_SCHEMA_TYPE(propType);
 
-  async search(
-    params: SearchParams,
-    language: Language = this.defaultLanguage
-  ): SearchResult {
-    const tokens = tokenize(params.term, language).values();
-    const indices = this.getIndices(params.properties);
-    const { limit = 10, offset = 0, exact = false } = params;
-    const results: object[] = new Array({ length: limit });
-    let totalResults = 0;
+			const propName = `${prefix}${prop}`;
 
-    const timeStart = getNanosecondsTime();
+			if (isNested) {
+				this.buildIndex(schema[prop] as PropertiesSchema, `${propName}.`);
+			} else {
+				this.index.set(propName, new Trie());
+			}
+		}
+	}
 
-    let i = 0;
-    let j = 0;
+	async search(
+		params: SearchParams,
+		language: Language = this.defaultLanguage
+	): SearchResult {
+		const tokens = tokenize(params.term, language).values();
+		const indices = this.getIndices(params.properties);
+		const { limit = 10, offset = 0, exact = false } = params;
+		const results: object[] = new Array({ length: limit });
+		let totalResults = 0;
 
-    for (const token of tokens) {
-      for (const index of indices) {
-        const documentIDs = await this.getDocumentIDsFromSearch({
-          ...params,
-          index: index,
-          term: token,
-          exact: exact,
-        });
+		const timeStart = getNanosecondsTime();
 
-        totalResults += documentIDs.size;
+		let i = 0;
+		let j = 0;
 
-        if (i >= limit) {
-          break;
-        }
+		for (const token of tokens) {
+			for (const index of indices) {
+				const documentIDs = await this.getDocumentIDsFromSearch({
+					...params,
+					index: index,
+					term: token,
+					exact: exact,
+				});
 
-        if (documentIDs.size) {
-          for (const id of documentIDs) {
-            if (j < offset) {
-              j++;
-              continue;
-            }
+				totalResults += documentIDs.size;
 
-            if (i >= limit) {
-              break;
-            }
+				if (i >= limit) {
+					break;
+				}
 
-            const fullDoc = this.docs.get(id);
-            results[i] = { id, ...fullDoc };
-            i++;
-          }
-        }
-      }
-    }
+				if (documentIDs.size) {
+					for (const id of documentIDs) {
+						if (j < offset) {
+							j++;
+							continue;
+						}
 
-    return {
-      elapsed: formatNanoseconds(getNanosecondsTime() - timeStart),
-      hits: results,
-      count: totalResults,
-    };
-  }
+						if (i >= limit) {
+							break;
+						}
 
-  private getIndices(indices: SearchParams["properties"]): string[] {
-    const knownIndices = [...this.index.keys()];
+						const fullDoc = this.docs.get(id);
+						results[i] = { id, ...fullDoc };
+						i++;
+					}
+				}
+			}
+		}
 
-    if (!indices) {
-      return knownIndices;
-    }
+		return {
+			elapsed: formatNanoseconds(getNanosecondsTime() - timeStart),
+			hits: results,
+			count: totalResults,
+		};
+	}
 
-    if (typeof indices === "string") {
-      if (indices === "*") {
-        return knownIndices;
-      } else {
-        throw ERRORS.INVALID_PROPERTY(indices, knownIndices);
-      }
-    }
+	private getIndices(indices: SearchParams["properties"]): string[] {
+		const knownIndices = [...this.index.keys()];
 
-    for (const index of indices as string[]) {
-      if (!knownIndices.includes(index)) {
-        throw ERRORS.INVALID_PROPERTY(index, knownIndices);
-      }
-    }
+		if (!indices) {
+			return knownIndices;
+		}
 
-    return indices as string[];
-  }
+		if (typeof indices === "string") {
+			if (indices === "*") {
+				return knownIndices;
+			} else {
+				throw ERRORS.INVALID_PROPERTY(indices, knownIndices);
+			}
+		}
 
-  async delete(docID: string): Promise<boolean> {
-    if (!this.docs.has(docID)) {
-      throw ERRORS.DOC_ID_DOES_NOT_EXISTS(docID);
-    }
+		for (const index of indices as string[]) {
+			if (!knownIndices.includes(index)) {
+				throw ERRORS.INVALID_PROPERTY(index, knownIndices);
+			}
+		}
 
-    const document = this.docs.get(docID)!;
+		return indices as string[];
+	}
 
-    for (const key in document) {
-      const idx = this.index.get(key)!;
-      const tokens = tokenize((document as any)[key]);
+	async delete(docID: string): Promise<boolean> {
+		if (!this.docs.has(docID)) {
+			throw ERRORS.DOC_ID_DOES_NOT_EXISTS(docID);
+		}
 
-      for (const token of tokens) {
-        if (idx.removeDocByWord(token, docID)) {
-          throw `Unable to remove document "${docID}" from index "${key}" on word "${token}".`;
-        }
-      }
-    }
+		const document = this.docs.get(docID)!;
 
-    this.docs.delete(docID);
+		for (const key in document) {
+			const idx = this.index.get(key)!;
+			const tokens = tokenize((document as any)[key]);
 
-    return true;
-  }
+			for (const token of tokens) {
+				if (idx.removeDocByWord(token, docID)) {
+					throw `Unable to remove document "${docID}" from index "${key}" on word "${token}".`;
+				}
+			}
+		}
 
-  private async getDocumentIDsFromSearch(
-    params: SearchParams & { index: string }
-  ): Promise<Set<string>> {
-    const idx = this.index.get(params.index);
-    const searchResult = idx?.find({
-      term: params.term,
-      exact: params.exact,
-      tolerance: params.tolerance,
-    });
-    const ids = new Set<string>();
+		this.docs.delete(docID);
 
-    for (const key in searchResult) {
-      for (const id of (searchResult as any)[key]) {
-        ids.add(id);
-      }
-    }
-    return ids;
-  }
+		return true;
+	}
 
-  public async insert(
-    doc: object,
-    language: Language = this.defaultLanguage
-  ): Promise<{ id: string }> {
-    const id = nanoid();
+	private async getDocumentIDsFromSearch(
+		params: SearchParams & { index: string }
+	): Promise<Set<string>> {
+		const idx = this.index.get(params.index);
+		const searchResult = idx?.find({
+			term: params.term,
+			exact: params.exact,
+			tolerance: params.tolerance,
+		});
+		const ids = new Set<string>();
 
-    if (!SUPPORTED_LANGUAGES.includes(language)) {
-      throw ERRORS.LANGUAGE_NOT_SUPPORTED(language);
-    }
+		for (const key in searchResult) {
+			for (const id of (searchResult as any)[key]) {
+				ids.add(id);
+			}
+		}
+		return ids;
+	}
 
-    if (!(await this.checkInsertDocSchema(doc))) {
-      throw ERRORS.INVALID_DOC_SCHEMA(this.schema, doc);
-    }
+	public async insert(
+		doc: object,
+		language: Language = this.defaultLanguage
+	): Promise<{ id: string }> {
+		const id = nanoid();
 
-    await this.queue.push({
-      id,
-      doc,
-      language,
-    });
+		if (!SUPPORTED_LANGUAGES.includes(language)) {
+			throw ERRORS.LANGUAGE_NOT_SUPPORTED(language);
+		}
 
-    return { id };
-  }
+		if (!(await this.checkInsertDocSchema(doc))) {
+			throw ERRORS.INVALID_DOC_SCHEMA(this.schema, doc);
+		}
 
-  private async _insert({ doc, id, language }: QueueDocParams): Promise<void> {
-    const index = this.index;
-    this.docs.set(id, doc);
+		await this.queue.push({
+			id,
+			doc,
+			language,
+		});
 
-    function recursiveTrieInsertion(doc: object) {
-      for (const key in doc) {
-        if (typeof (doc as any)[key] === "object") {
-          throw ERRORS.UNSUPPORTED_NESTED_PROPERTIES();
-          // @todo nested properties will be supported with the nexrt versions
-          // recursiveTrieInsertion((doc as any)[key]);
-        } else if (typeof (doc as any)[key] === "string") {
-          const requestedTrie = index.get(key);
-          const tokens = tokenize((doc as any)[key], language);
+		return { id };
+	}
 
-          for (const token of tokens) {
-            requestedTrie?.insert(token, id);
-          }
-        }
-      }
-    }
+	private async _insert({ doc, id, language }: QueueDocParams): Promise<void> {
+		const index = this.index;
+		this.docs.set(id, doc);
 
-    recursiveTrieInsertion(doc);
-  }
+		function recursiveTrieInsertion(doc: object, prefix = "") {
+			for (const key in doc) {
+				const isNested = typeof (doc as any)[key] === "object";
+				const propName = `${prefix}${key}`;
+				if (isNested) {
+					recursiveTrieInsertion((doc as any)[key], `${propName}.`);
+				} else if (typeof (doc as any)[key] === "string") {
+					// Use propName here because if doc is a nested object
+					// We will get the wrong index
+					const requestedTrie = index.get(propName);
+					const tokens = tokenize((doc as any)[key], language);
 
-  private async checkInsertDocSchema(
-    doc: QueueDocParams["doc"]
-  ): Promise<boolean> {
-    function recursiveCheck(
-      newDoc: QueueDocParams["doc"],
-      schema: PropertiesSchema
-    ): boolean {
-      for (const key in newDoc) {
-        if (!(key in schema)) {
-          return false;
-        }
+					for (const token of tokens) {
+						requestedTrie?.insert(token, id);
+					}
+				}
+			}
+		}
 
-        const propType = typeof (newDoc as any)[key];
+		recursiveTrieInsertion(doc);
+	}
 
-        if (propType === "object") {
-          recursiveCheck((newDoc as any)[key], schema);
-        } else {
-          if (typeof (newDoc as any)[key] !== schema[key]) {
-            return false;
-          }
-        }
-      }
+	private async checkInsertDocSchema(
+		doc: QueueDocParams["doc"]
+	): Promise<boolean> {
+		function recursiveCheck(
+			newDoc: QueueDocParams["doc"],
+			schema: PropertiesSchema
+		): boolean {
+			for (const key in newDoc) {
+				if (!(key in schema)) {
+					return false;
+				}
 
-      return true;
-    }
+				const propType = typeof (newDoc as any)[key];
 
-    return recursiveCheck(doc, this.schema);
-  }
+				if (propType === "object") {
+					recursiveCheck((newDoc as any)[key], schema);
+				} else {
+					if (typeof (newDoc as any)[key] !== schema[key]) {
+						return false;
+					}
+				}
+			}
+
+			return true;
+		}
+
+		return recursiveCheck(doc, this.schema);
+	}
 }

--- a/packages/lyra/src/types.d.ts
+++ b/packages/lyra/src/types.d.ts
@@ -2,15 +2,15 @@ import type { PropertiesSchema } from "./lyra";
 export type Nullable<T> = T | null;
 
 type ResolveTypes<TType> = TType extends "string"
-	? string
-	: TType extends "boolean"
-	? boolean
-	: TType extends "number"
-	? number
-	: TType extends PropertiesSchema
-	? { [P in keyof TType]: ResolveTypes<TType[P]> }
-	: never;
+  ? string
+  : TType extends "boolean"
+  ? boolean
+  : TType extends "number"
+  ? number
+  : TType extends PropertiesSchema
+  ? { [P in keyof TType]: ResolveTypes<TType[P]> }
+  : never;
 
 export type ResolveSchema<T extends PropertiesSchema> = {
-	[P in keyof T]: ResolveTypes<T[P]>;
+  [P in keyof T]: ResolveTypes<T[P]>;
 };

--- a/packages/lyra/src/types.d.ts
+++ b/packages/lyra/src/types.d.ts
@@ -1,1 +1,16 @@
+import type { PropertiesSchema } from "./lyra";
 export type Nullable<T> = T | null;
+
+type ResolveTypes<TType> = TType extends "string"
+	? string
+	: TType extends "boolean"
+	? boolean
+	: TType extends "number"
+	? number
+	: TType extends PropertiesSchema
+	? { [P in keyof TType]: ResolveTypes<TType[P]> }
+	: never;
+
+export type ResolveSchema<T extends PropertiesSchema> = {
+	[P in keyof T]: ResolveTypes<T[P]>;
+};

--- a/packages/lyra/tests/lyra.test.ts
+++ b/packages/lyra/tests/lyra.test.ts
@@ -1,418 +1,418 @@
 import { Lyra } from "../src/lyra";
 
 function getId({ id }: { id: string }) {
-	return id;
+  return id;
 }
 
 describe("defaultLanguage", () => {
-	it("should throw an error if the desired language is not supported", () => {
-		try {
-			new Lyra({
-				schema: {},
-				// @ts-expect-error latin is not supported
-				defaultLanguage: "latin",
-			});
-		} catch (e) {
-			expect(e).toMatchSnapshot();
-		}
-	});
+  it("should throw an error if the desired language is not supported", () => {
+    try {
+      new Lyra({
+        schema: {},
+        // @ts-expect-error latin is not supported
+        defaultLanguage: "latin",
+      });
+    } catch (e) {
+      expect(e).toMatchSnapshot();
+    }
+  });
 
-	it("should throw an error if the desired language is not supported during insertion", async () => {
-		try {
-			const db = new Lyra({
-				schema: { foo: "string" },
-			});
+  it("should throw an error if the desired language is not supported during insertion", async () => {
+    try {
+      const db = new Lyra({
+        schema: { foo: "string" },
+      });
 
-			await db.insert(
-				{
-					foo: "bar",
-				},
-				// @ts-expect-error latin is not supported
-				"latin"
-			);
-		} catch (e) {
-			expect(e).toMatchSnapshot();
-		}
-	});
+      await db.insert(
+        {
+          foo: "bar",
+        },
+        // @ts-expect-error latin is not supported
+        "latin"
+      );
+    } catch (e) {
+      expect(e).toMatchSnapshot();
+    }
+  });
 
-	it("should not throw if if the language is supported", () => {
-		try {
-			new Lyra({
-				schema: {},
-				defaultLanguage: "portugese",
-			});
-		} catch (e) {
-			expect(e).toBeUndefined();
-		}
-	});
+  it("should not throw if if the language is supported", () => {
+    try {
+      new Lyra({
+        schema: {},
+        defaultLanguage: "portugese",
+      });
+    } catch (e) {
+      expect(e).toBeUndefined();
+    }
+  });
 });
 
 describe("checkInsertDocSchema", () => {
-	it("should compare the inserted doc with the schema definition", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-			},
-		});
+  it("should compare the inserted doc with the schema definition", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+      },
+    });
 
-		expect(
-			await db.insert({ quote: "hello, world!", author: "me" }).then(getId)
-		).toBeDefined();
+    expect(
+      await db.insert({ quote: "hello, world!", author: "me" }).then(getId)
+    ).toBeDefined();
 
-		try {
-			await db.insert({ quote: "hello, world!", author: true });
-		} catch (err) {
-			expect(err).toMatchSnapshot();
-		}
+    try {
+      await db.insert({ quote: "hello, world!", author: true });
+    } catch (err) {
+      expect(err).toMatchSnapshot();
+    }
 
-		try {
-			await db.insert({
-				quote: "hello, world!",
-				authors: "author should be singular",
-			});
-		} catch (err) {
-			expect(err).toMatchSnapshot();
-		}
+    try {
+      await db.insert({
+        quote: "hello, world!",
+        authors: "author should be singular",
+      });
+    } catch (err) {
+      expect(err).toMatchSnapshot();
+    }
 
-		try {
-			await db.insert({ quote: "hello, world!", foo: { bar: 10 } });
-		} catch (err) {
-			expect(err).toMatchSnapshot();
-		}
-	});
+    try {
+      await db.insert({ quote: "hello, world!", foo: { bar: 10 } });
+    } catch (err) {
+      expect(err).toMatchSnapshot();
+    }
+  });
 });
 
 describe("lyra", () => {
-	it("should correctly insert and retrieve data", async () => {
-		const db = new Lyra({
-			schema: {
-				example: "string",
-			},
-		});
+  it("should correctly insert and retrieve data", async () => {
+    const db = new Lyra({
+      schema: {
+        example: "string",
+      },
+    });
 
-		const ex1Insert = await db.insert({ example: "The quick, brown, fox" });
-		const ex1Search = await db.search({
-			term: "quick",
-			properties: ["example"],
-		});
+    const ex1Insert = await db.insert({ example: "The quick, brown, fox" });
+    const ex1Search = await db.search({
+      term: "quick",
+      properties: ["example"],
+    });
 
-		expect(ex1Insert.id).toBeDefined();
-		expect(ex1Search.count).toBe(1);
-		expect(ex1Search.elapsed).toBeDefined();
-		expect((ex1Search.hits[0] as any).example).toBe("The quick, brown, fox");
-	});
+    expect(ex1Insert.id).toBeDefined();
+    expect(ex1Search.count).toBe(1);
+    expect(ex1Search.elapsed).toBeDefined();
+    expect((ex1Search.hits[0] as any).example).toBe("The quick, brown, fox");
+  });
 
-	it("should correctly paginate results", async () => {
-		const db = new Lyra({
-			schema: {
-				animal: "string",
-			},
-		});
+  it("should correctly paginate results", async () => {
+    const db = new Lyra({
+      schema: {
+        animal: "string",
+      },
+    });
 
-		await db.insert({ animal: "Quick brown fox" });
-		await db.insert({ animal: "Lazy dog" });
-		await db.insert({ animal: "Jumping penguin" });
-		await db.insert({ animal: "Fast chicken" });
-		await db.insert({ animal: "Fabolous ducks" });
-		await db.insert({ animal: "Fantastic horse" });
+    await db.insert({ animal: "Quick brown fox" });
+    await db.insert({ animal: "Lazy dog" });
+    await db.insert({ animal: "Jumping penguin" });
+    await db.insert({ animal: "Fast chicken" });
+    await db.insert({ animal: "Fabolous ducks" });
+    await db.insert({ animal: "Fantastic horse" });
 
-		const search1 = await db.search({ term: "f", limit: 1, offset: 0 });
-		const search2 = await db.search({ term: "f", limit: 1, offset: 1 });
-		const search3 = await db.search({ term: "f", limit: 1, offset: 2 });
-		const search4 = await db.search({ term: "f", limit: 2, offset: 2 });
+    const search1 = await db.search({ term: "f", limit: 1, offset: 0 });
+    const search2 = await db.search({ term: "f", limit: 1, offset: 1 });
+    const search3 = await db.search({ term: "f", limit: 1, offset: 2 });
+    const search4 = await db.search({ term: "f", limit: 2, offset: 2 });
 
-		expect(search1.count).toBe(4);
-		expect((search1.hits[0] as any).animal).toBe("Quick brown fox");
+    expect(search1.count).toBe(4);
+    expect((search1.hits[0] as any).animal).toBe("Quick brown fox");
 
-		expect(search2.count).toBe(4);
-		expect((search2.hits[0] as any).animal).toBe("Fast chicken");
+    expect(search2.count).toBe(4);
+    expect((search2.hits[0] as any).animal).toBe("Fast chicken");
 
-		expect(search3.count).toBe(4);
-		expect((search3.hits[0] as any).animal).toBe("Fabolous ducks");
+    expect(search3.count).toBe(4);
+    expect((search3.hits[0] as any).animal).toBe("Fabolous ducks");
 
-		expect(search4.count).toBe(4);
-		expect((search4.hits[0] as any).animal).toBe("Fabolous ducks");
-		expect((search4.hits[1] as any).animal).toBe("Fantastic horse");
-	});
+    expect(search4.count).toBe(4);
+    expect((search4.hits[0] as any).animal).toBe("Fabolous ducks");
+    expect((search4.hits[1] as any).animal).toBe("Fantastic horse");
+  });
 
-	it("Should throw an error when searching in non-existing indices", async () => {
-		const db = new Lyra({ schema: { foo: "string", baz: "string" } });
+  it("Should throw an error when searching in non-existing indices", async () => {
+    const db = new Lyra({ schema: { foo: "string", baz: "string" } });
 
-		try {
-			await db.search({
-				term: "foo",
-				properties: ["bar"],
-			});
-		} catch (err) {
-			expect(err).toMatchInlineSnapshot(
-				`"Invalid property name. Expected a wildcard string (\\"*\\") or array containing one of the following properties: foo, baz, but got: bar"`
-			);
-		}
-	});
+    try {
+      await db.search({
+        term: "foo",
+        properties: ["bar"],
+      });
+    } catch (err) {
+      expect(err).toMatchInlineSnapshot(
+        `"Invalid property name. Expected a wildcard string (\\"*\\") or array containing one of the following properties: foo, baz, but got: bar"`
+      );
+    }
+  });
 
-	it("Should correctly remove a document after its insertion", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-			},
-		});
+  it("Should correctly remove a document after its insertion", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+      },
+    });
 
-		const { id: id1 } = await db.insert({
-			quote: "Be yourself; everyone else is already taken.",
-			author: "Oscar Wilde",
-		});
+    const { id: id1 } = await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+    });
 
-		const { id: id2 } = await db.insert({
-			quote:
-				"To live is the rarest thing in the world. Most people exist, that is all.",
-			author: "Oscar Wilde",
-		});
+    const { id: id2 } = await db.insert({
+      quote:
+        "To live is the rarest thing in the world. Most people exist, that is all.",
+      author: "Oscar Wilde",
+    });
 
-		await db.insert({
-			quote: "So many books, so little time.",
-			author: "Frank Zappa",
-		});
+    await db.insert({
+      quote: "So many books, so little time.",
+      author: "Frank Zappa",
+    });
 
-		const res = await db.delete(id1);
+    const res = await db.delete(id1);
 
-		const searchResult = await db.search({
-			term: "Oscar",
-			properties: ["author"],
-		});
+    const searchResult = await db.search({
+      term: "Oscar",
+      properties: ["author"],
+    });
 
-		expect(res).toBeTruthy();
-		expect(searchResult.count).toBe(1);
-		expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
-		expect((searchResult.hits[0] as any).quote).toBe(
-			"To live is the rarest thing in the world. Most people exist, that is all."
-		);
-		expect((searchResult.hits[0] as any).id).toBe(id2);
-	});
+    expect(res).toBeTruthy();
+    expect(searchResult.count).toBe(1);
+    expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
+    expect((searchResult.hits[0] as any).quote).toBe(
+      "To live is the rarest thing in the world. Most people exist, that is all."
+    );
+    expect((searchResult.hits[0] as any).id).toBe(id2);
+  });
 
-	it("Should preserve identical docs after deletion", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-			},
-		});
+  it("Should preserve identical docs after deletion", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+      },
+    });
 
-		const { id: id1 } = await db.insert({
-			quote: "Be yourself; everyone else is already taken.",
-			author: "Oscar Wilde",
-		});
+    const { id: id1 } = await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+    });
 
-		const { id: id2 } = await db.insert({
-			quote: "Be yourself; everyone else is already taken.",
-			author: "Oscar Wilde",
-		});
+    const { id: id2 } = await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+    });
 
-		await db.insert({
-			quote: "So many books, so little time.",
-			author: "Frank Zappa",
-		});
+    await db.insert({
+      quote: "So many books, so little time.",
+      author: "Frank Zappa",
+    });
 
-		const res = await db.delete(id1);
+    const res = await db.delete(id1);
 
-		const searchResult = await db.search({
-			term: "Oscar",
-			properties: ["author"],
-		});
+    const searchResult = await db.search({
+      term: "Oscar",
+      properties: ["author"],
+    });
 
-		const searchResult2 = await db.search({
-			term: "already",
-			properties: ["quote"],
-		});
+    const searchResult2 = await db.search({
+      term: "already",
+      properties: ["quote"],
+    });
 
-		expect(res).toBeTruthy();
-		expect(searchResult.count).toBe(1);
-		expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
-		expect((searchResult.hits[0] as any).quote).toBe(
-			"Be yourself; everyone else is already taken."
-		);
-		expect((searchResult.hits[0] as any).id).toBe(id2);
+    expect(res).toBeTruthy();
+    expect(searchResult.count).toBe(1);
+    expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
+    expect((searchResult.hits[0] as any).quote).toBe(
+      "Be yourself; everyone else is already taken."
+    );
+    expect((searchResult.hits[0] as any).id).toBe(id2);
 
-		expect(searchResult2.count).toBe(1);
-		expect((searchResult2.hits[0] as any).author).toBe("Oscar Wilde");
-		expect((searchResult2.hits[0] as any).quote).toBe(
-			"Be yourself; everyone else is already taken."
-		);
-		expect((searchResult2.hits[0] as any).id).toBe(id2);
-	});
+    expect(searchResult2.count).toBe(1);
+    expect((searchResult2.hits[0] as any).author).toBe("Oscar Wilde");
+    expect((searchResult2.hits[0] as any).quote).toBe(
+      "Be yourself; everyone else is already taken."
+    );
+    expect((searchResult2.hits[0] as any).id).toBe(id2);
+  });
 
-	it("Should be able to insert documens with non-searchable fields", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-				isFavorite: "boolean",
-				rating: "number",
-			},
-		});
+  it("Should be able to insert documens with non-searchable fields", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+        isFavorite: "boolean",
+        rating: "number",
+      },
+    });
 
-		await db.insert({
-			quote: "Be yourself; everyone else is already taken.",
-			author: "Oscar Wilde",
-			isFavorite: false,
-			rating: 4,
-		});
+    await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+      isFavorite: false,
+      rating: 4,
+    });
 
-		await db.insert({
-			quote: "So many books, so little time.",
-			author: "Frank Zappa",
-			isFavorite: true,
-			rating: 5,
-		});
+    await db.insert({
+      quote: "So many books, so little time.",
+      author: "Frank Zappa",
+      isFavorite: true,
+      rating: 5,
+    });
 
-		const search = await db.search({
-			term: "frank",
-		});
+    const search = await db.search({
+      term: "frank",
+    });
 
-		expect(search.count).toBe(1);
-		expect((search.hits[0] as any).author).toBe("Frank Zappa");
-	});
+    expect(search.count).toBe(1);
+    expect((search.hits[0] as any).author).toBe("Frank Zappa");
+  });
 
-	it("Should exact match", async () => {
-		const db = new Lyra({
-			schema: {
-				author: "string",
-				quote: "string",
-			},
-		});
+  it("Should exact match", async () => {
+    const db = new Lyra({
+      schema: {
+        author: "string",
+        quote: "string",
+      },
+    });
 
-		await db.insert({
-			quote: "Be yourself; everyone else is already taken.",
-			author: "Oscar Wilde",
-		});
+    await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+    });
 
-		const partialSearch = await db.search({
-			term: "alr",
-			exact: true,
-		});
+    const partialSearch = await db.search({
+      term: "alr",
+      exact: true,
+    });
 
-		expect(partialSearch.count).toBe(0);
+    expect(partialSearch.count).toBe(0);
 
-		const exactSearch = await db.search({
-			term: "already",
-			exact: true,
-		});
+    const exactSearch = await db.search({
+      term: "already",
+      exact: true,
+    });
 
-		expect(exactSearch.count).toBe(1);
-		expect((exactSearch.hits[0] as any).quote).toBe(
-			"Be yourself; everyone else is already taken."
-		);
-		expect((exactSearch.hits[0] as any).author).toBe("Oscar Wilde");
-	});
+    expect(exactSearch.count).toBe(1);
+    expect((exactSearch.hits[0] as any).quote).toBe(
+      "Be yourself; everyone else is already taken."
+    );
+    expect((exactSearch.hits[0] as any).author).toBe("Oscar Wilde");
+  });
 
-	it("Shouldn't tolerate typos", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-			},
-		});
+  it("Shouldn't tolerate typos", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+      },
+    });
 
-		await db.insert({
-			quote:
-				"Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
-			author: "Sara A. Lourie",
-		});
+    await db.insert({
+      quote:
+        "Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
+      author: "Sara A. Lourie",
+    });
 
-		const search = await db.search({
-			term: "seahrse",
-			tolerance: 0,
-		});
+    const search = await db.search({
+      term: "seahrse",
+      tolerance: 0,
+    });
 
-		expect(search.count).toBe(0);
-	});
+    expect(search.count).toBe(0);
+  });
 
-	it("Should tolerate typos", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-			},
-		});
+  it("Should tolerate typos", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+      },
+    });
 
-		await db.insert({
-			quote:
-				"Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
-			author: "Sara A. Lourie",
-		});
+    await db.insert({
+      quote:
+        "Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
+      author: "Sara A. Lourie",
+    });
 
-		await db.insert({
-			quote:
-				"Seahorses look mythical, like dragons, but these magnificent shy creatures are real.",
-			author: "Jennifer Keats Curtis",
-		});
+    await db.insert({
+      quote:
+        "Seahorses look mythical, like dragons, but these magnificent shy creatures are real.",
+      author: "Jennifer Keats Curtis",
+    });
 
-		const tolerantSearch = await db.search({
-			term: "seahrse",
-			tolerance: 1,
-		});
+    const tolerantSearch = await db.search({
+      term: "seahrse",
+      tolerance: 1,
+    });
 
-		expect(tolerantSearch.count).toBe(2);
+    expect(tolerantSearch.count).toBe(2);
 
-		const moreTolerantSearch = await db.search({
-			term: "sahrse",
-			tolerance: 3,
-		});
+    const moreTolerantSearch = await db.search({
+      term: "sahrse",
+      tolerance: 3,
+    });
 
-		expect(moreTolerantSearch.count).toBe(2);
-	});
+    expect(moreTolerantSearch.count).toBe(2);
+  });
 
-	it("Should support nested properties", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: {
-					name: "string",
-					surname: "string",
-				},
-			},
-		});
+  it("Should support nested properties", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: {
+          name: "string",
+          surname: "string",
+        },
+      },
+    });
 
-		await db.insert({
-			quote: "Harry Potter, the boy who lived, come to die. Avada kedavra.",
-			author: {
-				name: "Tom",
-				surname: "Riddle",
-			},
-		});
+    await db.insert({
+      quote: "Harry Potter, the boy who lived, come to die. Avada kedavra.",
+      author: {
+        name: "Tom",
+        surname: "Riddle",
+      },
+    });
 
-		await db.insert({
-			quote: "I am Homer Simpson.",
-			author: {
-				name: "Homer",
-				surname: "Simpson",
-			},
-		});
+    await db.insert({
+      quote: "I am Homer Simpson.",
+      author: {
+        name: "Homer",
+        surname: "Simpson",
+      },
+    });
 
-		const resultAuthorSurname = await db.search({
-			term: "Riddle",
-			properties: ["author.surname"],
-		});
+    const resultAuthorSurname = await db.search({
+      term: "Riddle",
+      properties: ["author.surname"],
+    });
 
-		const resultAuthorName = await db.search({
-			term: "Riddle",
-			properties: ["author.name"],
-		});
+    const resultAuthorName = await db.search({
+      term: "Riddle",
+      properties: ["author.name"],
+    });
 
-		const resultSimpsonQuote = await db.search({
-			term: "Homer",
-			properties: ["quote"],
-		});
+    const resultSimpsonQuote = await db.search({
+      term: "Homer",
+      properties: ["quote"],
+    });
 
-		const resultSimpsonAuthorName = await db.search({
-			term: "Homer",
-			properties: ["author.name"],
-		});
+    const resultSimpsonAuthorName = await db.search({
+      term: "Homer",
+      properties: ["author.name"],
+    });
 
-		expect(resultSimpsonAuthorName.count).toBe(1);
-		expect(resultSimpsonQuote.count).toBe(1);
-		expect(resultAuthorSurname.count).toBe(1);
-		expect(resultAuthorName.count).toBe(0);
-	});
+    expect(resultSimpsonAuthorName.count).toBe(1);
+    expect(resultSimpsonQuote.count).toBe(1);
+    expect(resultAuthorSurname.count).toBe(1);
+    expect(resultAuthorName.count).toBe(0);
+  });
 });

--- a/packages/lyra/tests/lyra.test.ts
+++ b/packages/lyra/tests/lyra.test.ts
@@ -1,418 +1,418 @@
 import { Lyra } from "../src/lyra";
 
 function getId({ id }: { id: string }) {
-	return id;
+  return id;
 }
 
 describe("defaultLanguage", () => {
-	it("should throw an error if the desired language is not supported", () => {
-		try {
-			new Lyra({
-				schema: {},
-				// @ts-expect-error latin is not supported
-				defaultLanguage: "latin",
-			});
-		} catch (e) {
-			expect(e).toMatchSnapshot();
-		}
-	});
+  it("should throw an error if the desired language is not supported", () => {
+    try {
+      new Lyra({
+        schema: {},
+        // @ts-expect-error latin is not supported
+        defaultLanguage: "latin",
+      });
+    } catch (e) {
+      expect(e).toMatchSnapshot();
+    }
+  });
 
-	it("should throw an error if the desired language is not supported during insertion", async () => {
-		try {
-			const db = new Lyra({
-				schema: { foo: "string" },
-			});
+  it("should throw an error if the desired language is not supported during insertion", async () => {
+    try {
+      const db = new Lyra({
+        schema: { foo: "string" },
+      });
 
-			await db.insert(
-				{
-					foo: "bar",
-				},
-				// @ts-expect-error latin is not supported
-				"latin"
-			);
-		} catch (e) {
-			expect(e).toMatchSnapshot();
-		}
-	});
+      await db.insert(
+        {
+          foo: "bar",
+        },
+        // @ts-expect-error latin is not supported
+        "latin"
+      );
+    } catch (e) {
+      expect(e).toMatchSnapshot();
+    }
+  });
 
-	it("should not throw if if the language is supported", () => {
-		try {
-			new Lyra({
-				schema: {},
-				defaultLanguage: "portugese",
-			});
-		} catch (e) {
-			expect(e).toBeUndefined();
-		}
-	});
+  it("should not throw if if the language is supported", () => {
+    try {
+      new Lyra({
+        schema: {},
+        defaultLanguage: "portugese",
+      });
+    } catch (e) {
+      expect(e).toBeUndefined();
+    }
+  });
 });
 
 describe("checkInsertDocSchema", () => {
-	it("should compare the inserted doc with the schema definition", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-			},
-		});
+  it("should compare the inserted doc with the schema definition", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+      },
+    });
 
-		expect(
-			await db.insert({ quote: "hello, world!", author: "me" }).then(getId)
-		).toBeDefined();
+    expect(
+      await db.insert({ quote: "hello, world!", author: "me" }).then(getId)
+    ).toBeDefined();
 
-		try {
-			await db.insert({ quote: "hello, world!", author: true } as any);
-		} catch (err) {
-			expect(err).toMatchSnapshot();
-		}
+    try {
+      await db.insert({ quote: "hello, world!", author: true } as any);
+    } catch (err) {
+      expect(err).toMatchSnapshot();
+    }
 
-		try {
-			await db.insert({
-				quote: "hello, world!",
-				authors: "author should be singular",
-			} as any);
-		} catch (err) {
-			expect(err).toMatchSnapshot();
-		}
+    try {
+      await db.insert({
+        quote: "hello, world!",
+        authors: "author should be singular",
+      } as any);
+    } catch (err) {
+      expect(err).toMatchSnapshot();
+    }
 
-		try {
-			await db.insert({ quote: "hello, world!", foo: { bar: 10 } } as any);
-		} catch (err) {
-			expect(err).toMatchSnapshot();
-		}
-	});
+    try {
+      await db.insert({ quote: "hello, world!", foo: { bar: 10 } } as any);
+    } catch (err) {
+      expect(err).toMatchSnapshot();
+    }
+  });
 });
 
 describe("lyra", () => {
-	it("should correctly insert and retrieve data", async () => {
-		const db = new Lyra({
-			schema: {
-				example: "string",
-			},
-		});
+  it("should correctly insert and retrieve data", async () => {
+    const db = new Lyra({
+      schema: {
+        example: "string",
+      },
+    });
 
-		const ex1Insert = await db.insert({ example: "The quick, brown, fox" });
-		const ex1Search = await db.search({
-			term: "quick",
-			properties: ["example"],
-		});
+    const ex1Insert = await db.insert({ example: "The quick, brown, fox" });
+    const ex1Search = await db.search({
+      term: "quick",
+      properties: ["example"],
+    });
 
-		expect(ex1Insert.id).toBeDefined();
-		expect(ex1Search.count).toBe(1);
-		expect(ex1Search.elapsed).toBeDefined();
-		expect((ex1Search.hits[0] as any).example).toBe("The quick, brown, fox");
-	});
+    expect(ex1Insert.id).toBeDefined();
+    expect(ex1Search.count).toBe(1);
+    expect(ex1Search.elapsed).toBeDefined();
+    expect((ex1Search.hits[0] as any).example).toBe("The quick, brown, fox");
+  });
 
-	it("should correctly paginate results", async () => {
-		const db = new Lyra({
-			schema: {
-				animal: "string",
-			},
-		});
+  it("should correctly paginate results", async () => {
+    const db = new Lyra({
+      schema: {
+        animal: "string",
+      },
+    });
 
-		await db.insert({ animal: "Quick brown fox" });
-		await db.insert({ animal: "Lazy dog" });
-		await db.insert({ animal: "Jumping penguin" });
-		await db.insert({ animal: "Fast chicken" });
-		await db.insert({ animal: "Fabolous ducks" });
-		await db.insert({ animal: "Fantastic horse" });
+    await db.insert({ animal: "Quick brown fox" });
+    await db.insert({ animal: "Lazy dog" });
+    await db.insert({ animal: "Jumping penguin" });
+    await db.insert({ animal: "Fast chicken" });
+    await db.insert({ animal: "Fabolous ducks" });
+    await db.insert({ animal: "Fantastic horse" });
 
-		const search1 = await db.search({ term: "f", limit: 1, offset: 0 });
-		const search2 = await db.search({ term: "f", limit: 1, offset: 1 });
-		const search3 = await db.search({ term: "f", limit: 1, offset: 2 });
-		const search4 = await db.search({ term: "f", limit: 2, offset: 2 });
+    const search1 = await db.search({ term: "f", limit: 1, offset: 0 });
+    const search2 = await db.search({ term: "f", limit: 1, offset: 1 });
+    const search3 = await db.search({ term: "f", limit: 1, offset: 2 });
+    const search4 = await db.search({ term: "f", limit: 2, offset: 2 });
 
-		expect(search1.count).toBe(4);
-		expect((search1.hits[0] as any).animal).toBe("Quick brown fox");
+    expect(search1.count).toBe(4);
+    expect((search1.hits[0] as any).animal).toBe("Quick brown fox");
 
-		expect(search2.count).toBe(4);
-		expect((search2.hits[0] as any).animal).toBe("Fast chicken");
+    expect(search2.count).toBe(4);
+    expect((search2.hits[0] as any).animal).toBe("Fast chicken");
 
-		expect(search3.count).toBe(4);
-		expect((search3.hits[0] as any).animal).toBe("Fabolous ducks");
+    expect(search3.count).toBe(4);
+    expect((search3.hits[0] as any).animal).toBe("Fabolous ducks");
 
-		expect(search4.count).toBe(4);
-		expect((search4.hits[0] as any).animal).toBe("Fabolous ducks");
-		expect((search4.hits[1] as any).animal).toBe("Fantastic horse");
-	});
+    expect(search4.count).toBe(4);
+    expect((search4.hits[0] as any).animal).toBe("Fabolous ducks");
+    expect((search4.hits[1] as any).animal).toBe("Fantastic horse");
+  });
 
-	it("Should throw an error when searching in non-existing indices", async () => {
-		const db = new Lyra({ schema: { foo: "string", baz: "string" } });
+  it("Should throw an error when searching in non-existing indices", async () => {
+    const db = new Lyra({ schema: { foo: "string", baz: "string" } });
 
-		try {
-			await db.search({
-				term: "foo",
-				properties: ["bar"],
-			});
-		} catch (err) {
-			expect(err).toMatchInlineSnapshot(
-				`"Invalid property name. Expected a wildcard string (\\"*\\") or array containing one of the following properties: foo, baz, but got: bar"`
-			);
-		}
-	});
+    try {
+      await db.search({
+        term: "foo",
+        properties: ["bar"],
+      });
+    } catch (err) {
+      expect(err).toMatchInlineSnapshot(
+        `"Invalid property name. Expected a wildcard string (\\"*\\") or array containing one of the following properties: foo, baz, but got: bar"`
+      );
+    }
+  });
 
-	it("Should correctly remove a document after its insertion", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-			},
-		});
+  it("Should correctly remove a document after its insertion", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+      },
+    });
 
-		const { id: id1 } = await db.insert({
-			quote: "Be yourself; everyone else is already taken.",
-			author: "Oscar Wilde",
-		});
+    const { id: id1 } = await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+    });
 
-		const { id: id2 } = await db.insert({
-			quote:
-				"To live is the rarest thing in the world. Most people exist, that is all.",
-			author: "Oscar Wilde",
-		});
+    const { id: id2 } = await db.insert({
+      quote:
+        "To live is the rarest thing in the world. Most people exist, that is all.",
+      author: "Oscar Wilde",
+    });
 
-		await db.insert({
-			quote: "So many books, so little time.",
-			author: "Frank Zappa",
-		});
+    await db.insert({
+      quote: "So many books, so little time.",
+      author: "Frank Zappa",
+    });
 
-		const res = await db.delete(id1);
+    const res = await db.delete(id1);
 
-		const searchResult = await db.search({
-			term: "Oscar",
-			properties: ["author"],
-		});
+    const searchResult = await db.search({
+      term: "Oscar",
+      properties: ["author"],
+    });
 
-		expect(res).toBeTruthy();
-		expect(searchResult.count).toBe(1);
-		expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
-		expect((searchResult.hits[0] as any).quote).toBe(
-			"To live is the rarest thing in the world. Most people exist, that is all."
-		);
-		expect((searchResult.hits[0] as any).id).toBe(id2);
-	});
+    expect(res).toBeTruthy();
+    expect(searchResult.count).toBe(1);
+    expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
+    expect((searchResult.hits[0] as any).quote).toBe(
+      "To live is the rarest thing in the world. Most people exist, that is all."
+    );
+    expect((searchResult.hits[0] as any).id).toBe(id2);
+  });
 
-	it("Should preserve identical docs after deletion", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-			},
-		});
+  it("Should preserve identical docs after deletion", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+      },
+    });
 
-		const { id: id1 } = await db.insert({
-			quote: "Be yourself; everyone else is already taken.",
-			author: "Oscar Wilde",
-		});
+    const { id: id1 } = await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+    });
 
-		const { id: id2 } = await db.insert({
-			quote: "Be yourself; everyone else is already taken.",
-			author: "Oscar Wilde",
-		});
+    const { id: id2 } = await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+    });
 
-		await db.insert({
-			quote: "So many books, so little time.",
-			author: "Frank Zappa",
-		});
+    await db.insert({
+      quote: "So many books, so little time.",
+      author: "Frank Zappa",
+    });
 
-		const res = await db.delete(id1);
+    const res = await db.delete(id1);
 
-		const searchResult = await db.search({
-			term: "Oscar",
-			properties: ["author"],
-		});
+    const searchResult = await db.search({
+      term: "Oscar",
+      properties: ["author"],
+    });
 
-		const searchResult2 = await db.search({
-			term: "already",
-			properties: ["quote"],
-		});
+    const searchResult2 = await db.search({
+      term: "already",
+      properties: ["quote"],
+    });
 
-		expect(res).toBeTruthy();
-		expect(searchResult.count).toBe(1);
-		expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
-		expect((searchResult.hits[0] as any).quote).toBe(
-			"Be yourself; everyone else is already taken."
-		);
-		expect((searchResult.hits[0] as any).id).toBe(id2);
+    expect(res).toBeTruthy();
+    expect(searchResult.count).toBe(1);
+    expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
+    expect((searchResult.hits[0] as any).quote).toBe(
+      "Be yourself; everyone else is already taken."
+    );
+    expect((searchResult.hits[0] as any).id).toBe(id2);
 
-		expect(searchResult2.count).toBe(1);
-		expect((searchResult2.hits[0] as any).author).toBe("Oscar Wilde");
-		expect((searchResult2.hits[0] as any).quote).toBe(
-			"Be yourself; everyone else is already taken."
-		);
-		expect((searchResult2.hits[0] as any).id).toBe(id2);
-	});
+    expect(searchResult2.count).toBe(1);
+    expect((searchResult2.hits[0] as any).author).toBe("Oscar Wilde");
+    expect((searchResult2.hits[0] as any).quote).toBe(
+      "Be yourself; everyone else is already taken."
+    );
+    expect((searchResult2.hits[0] as any).id).toBe(id2);
+  });
 
-	it("Should be able to insert documens with non-searchable fields", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-				isFavorite: "boolean",
-				rating: "number",
-			},
-		});
+  it("Should be able to insert documens with non-searchable fields", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+        isFavorite: "boolean",
+        rating: "number",
+      },
+    });
 
-		await db.insert({
-			quote: "Be yourself; everyone else is already taken.",
-			author: "Oscar Wilde",
-			isFavorite: false,
-			rating: 4,
-		});
+    await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+      isFavorite: false,
+      rating: 4,
+    });
 
-		await db.insert({
-			quote: "So many books, so little time.",
-			author: "Frank Zappa",
-			isFavorite: true,
-			rating: 5,
-		});
+    await db.insert({
+      quote: "So many books, so little time.",
+      author: "Frank Zappa",
+      isFavorite: true,
+      rating: 5,
+    });
 
-		const search = await db.search({
-			term: "frank",
-		});
+    const search = await db.search({
+      term: "frank",
+    });
 
-		expect(search.count).toBe(1);
-		expect((search.hits[0] as any).author).toBe("Frank Zappa");
-	});
+    expect(search.count).toBe(1);
+    expect((search.hits[0] as any).author).toBe("Frank Zappa");
+  });
 
-	it("Should exact match", async () => {
-		const db = new Lyra({
-			schema: {
-				author: "string",
-				quote: "string",
-			},
-		});
+  it("Should exact match", async () => {
+    const db = new Lyra({
+      schema: {
+        author: "string",
+        quote: "string",
+      },
+    });
 
-		await db.insert({
-			quote: "Be yourself; everyone else is already taken.",
-			author: "Oscar Wilde",
-		});
+    await db.insert({
+      quote: "Be yourself; everyone else is already taken.",
+      author: "Oscar Wilde",
+    });
 
-		const partialSearch = await db.search({
-			term: "alr",
-			exact: true,
-		});
+    const partialSearch = await db.search({
+      term: "alr",
+      exact: true,
+    });
 
-		expect(partialSearch.count).toBe(0);
+    expect(partialSearch.count).toBe(0);
 
-		const exactSearch = await db.search({
-			term: "already",
-			exact: true,
-		});
+    const exactSearch = await db.search({
+      term: "already",
+      exact: true,
+    });
 
-		expect(exactSearch.count).toBe(1);
-		expect((exactSearch.hits[0] as any).quote).toBe(
-			"Be yourself; everyone else is already taken."
-		);
-		expect((exactSearch.hits[0] as any).author).toBe("Oscar Wilde");
-	});
+    expect(exactSearch.count).toBe(1);
+    expect((exactSearch.hits[0] as any).quote).toBe(
+      "Be yourself; everyone else is already taken."
+    );
+    expect((exactSearch.hits[0] as any).author).toBe("Oscar Wilde");
+  });
 
-	it("Shouldn't tolerate typos", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-			},
-		});
+  it("Shouldn't tolerate typos", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+      },
+    });
 
-		await db.insert({
-			quote:
-				"Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
-			author: "Sara A. Lourie",
-		});
+    await db.insert({
+      quote:
+        "Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
+      author: "Sara A. Lourie",
+    });
 
-		const search = await db.search({
-			term: "seahrse",
-			tolerance: 0,
-		});
+    const search = await db.search({
+      term: "seahrse",
+      tolerance: 0,
+    });
 
-		expect(search.count).toBe(0);
-	});
+    expect(search.count).toBe(0);
+  });
 
-	it("Should tolerate typos", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: "string",
-			},
-		});
+  it("Should tolerate typos", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: "string",
+      },
+    });
 
-		await db.insert({
-			quote:
-				"Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
-			author: "Sara A. Lourie",
-		});
+    await db.insert({
+      quote:
+        "Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
+      author: "Sara A. Lourie",
+    });
 
-		await db.insert({
-			quote:
-				"Seahorses look mythical, like dragons, but these magnificent shy creatures are real.",
-			author: "Jennifer Keats Curtis",
-		});
+    await db.insert({
+      quote:
+        "Seahorses look mythical, like dragons, but these magnificent shy creatures are real.",
+      author: "Jennifer Keats Curtis",
+    });
 
-		const tolerantSearch = await db.search({
-			term: "seahrse",
-			tolerance: 1,
-		});
+    const tolerantSearch = await db.search({
+      term: "seahrse",
+      tolerance: 1,
+    });
 
-		expect(tolerantSearch.count).toBe(2);
+    expect(tolerantSearch.count).toBe(2);
 
-		const moreTolerantSearch = await db.search({
-			term: "sahrse",
-			tolerance: 3,
-		});
+    const moreTolerantSearch = await db.search({
+      term: "sahrse",
+      tolerance: 3,
+    });
 
-		expect(moreTolerantSearch.count).toBe(2);
-	});
+    expect(moreTolerantSearch.count).toBe(2);
+  });
 
-	it("Should support nested properties", async () => {
-		const db = new Lyra({
-			schema: {
-				quote: "string",
-				author: {
-					name: "string",
-					surname: "string",
-				},
-			},
-		});
+  it("Should support nested properties", async () => {
+    const db = new Lyra({
+      schema: {
+        quote: "string",
+        author: {
+          name: "string",
+          surname: "string",
+        },
+      },
+    });
 
-		await db.insert({
-			quote: "Harry Potter, the boy who lived, come to die. Avada kedavra.",
-			author: {
-				name: "Tom",
-				surname: "Riddle",
-			},
-		});
+    await db.insert({
+      quote: "Harry Potter, the boy who lived, come to die. Avada kedavra.",
+      author: {
+        name: "Tom",
+        surname: "Riddle",
+      },
+    });
 
-		await db.insert({
-			quote: "I am Homer Simpson.",
-			author: {
-				name: "Homer",
-				surname: "Simpson",
-			},
-		});
+    await db.insert({
+      quote: "I am Homer Simpson.",
+      author: {
+        name: "Homer",
+        surname: "Simpson",
+      },
+    });
 
-		const resultAuthorSurname = await db.search({
-			term: "Riddle",
-			properties: ["author.surname"],
-		});
+    const resultAuthorSurname = await db.search({
+      term: "Riddle",
+      properties: ["author.surname"],
+    });
 
-		const resultAuthorName = await db.search({
-			term: "Riddle",
-			properties: ["author.name"],
-		});
+    const resultAuthorName = await db.search({
+      term: "Riddle",
+      properties: ["author.name"],
+    });
 
-		const resultSimpsonQuote = await db.search({
-			term: "Homer",
-			properties: ["quote"],
-		});
+    const resultSimpsonQuote = await db.search({
+      term: "Homer",
+      properties: ["quote"],
+    });
 
-		const resultSimpsonAuthorName = await db.search({
-			term: "Homer",
-			properties: ["author.name"],
-		});
+    const resultSimpsonAuthorName = await db.search({
+      term: "Homer",
+      properties: ["author.name"],
+    });
 
-		expect(resultSimpsonAuthorName.count).toBe(1);
-		expect(resultSimpsonQuote.count).toBe(1);
-		expect(resultAuthorSurname.count).toBe(1);
-		expect(resultAuthorName.count).toBe(0);
-	});
+    expect(resultSimpsonAuthorName.count).toBe(1);
+    expect(resultSimpsonQuote.count).toBe(1);
+    expect(resultAuthorSurname.count).toBe(1);
+    expect(resultAuthorName.count).toBe(0);
+  });
 });

--- a/packages/lyra/tests/lyra.test.ts
+++ b/packages/lyra/tests/lyra.test.ts
@@ -1,365 +1,418 @@
 import { Lyra } from "../src/lyra";
 
 function getId({ id }: { id: string }) {
-  return id;
+	return id;
 }
 
 describe("defaultLanguage", () => {
-  it("should throw an error if the desired language is not supported", () => {
-    try {
-      new Lyra({
-        schema: {},
-        // @ts-expect-error latin is not supported
-        defaultLanguage: "latin",
-      });
-    } catch (e) {
-      expect(e).toMatchSnapshot();
-    }
-  });
+	it("should throw an error if the desired language is not supported", () => {
+		try {
+			new Lyra({
+				schema: {},
+				// @ts-expect-error latin is not supported
+				defaultLanguage: "latin",
+			});
+		} catch (e) {
+			expect(e).toMatchSnapshot();
+		}
+	});
 
-  it("should throw an error if the desired language is not supported during insertion", async () => {
-    try {
-      const db = new Lyra({
-        schema: { foo: "string" },
-      });
+	it("should throw an error if the desired language is not supported during insertion", async () => {
+		try {
+			const db = new Lyra({
+				schema: { foo: "string" },
+			});
 
-      await db.insert(
-        {
-          foo: "bar",
-        },
-        // @ts-expect-error latin is not supported
-        "latin"
-      );
-    } catch (e) {
-      expect(e).toMatchSnapshot();
-    }
-  });
+			await db.insert(
+				{
+					foo: "bar",
+				},
+				// @ts-expect-error latin is not supported
+				"latin"
+			);
+		} catch (e) {
+			expect(e).toMatchSnapshot();
+		}
+	});
 
-  it("should not throw if if the language is supported", () => {
-    try {
-      new Lyra({
-        schema: {},
-        defaultLanguage: "portugese",
-      });
-    } catch (e) {
-      expect(e).toBeUndefined();
-    }
-  });
+	it("should not throw if if the language is supported", () => {
+		try {
+			new Lyra({
+				schema: {},
+				defaultLanguage: "portugese",
+			});
+		} catch (e) {
+			expect(e).toBeUndefined();
+		}
+	});
 });
 
 describe("checkInsertDocSchema", () => {
-  it("should compare the inserted doc with the schema definition", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-      },
-    });
+	it("should compare the inserted doc with the schema definition", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+			},
+		});
 
-    expect(
-      await db.insert({ quote: "hello, world!", author: "me" }).then(getId)
-    ).toBeDefined();
+		expect(
+			await db.insert({ quote: "hello, world!", author: "me" }).then(getId)
+		).toBeDefined();
 
-    try {
-      await db.insert({ quote: "hello, world!", author: true });
-    } catch (err) {
-      expect(err).toMatchSnapshot();
-    }
+		try {
+			await db.insert({ quote: "hello, world!", author: true });
+		} catch (err) {
+			expect(err).toMatchSnapshot();
+		}
 
-    try {
-      await db.insert({
-        quote: "hello, world!",
-        authors: "author should be singular",
-      });
-    } catch (err) {
-      expect(err).toMatchSnapshot();
-    }
+		try {
+			await db.insert({
+				quote: "hello, world!",
+				authors: "author should be singular",
+			});
+		} catch (err) {
+			expect(err).toMatchSnapshot();
+		}
 
-    try {
-      await db.insert({ quote: "hello, world!", foo: { bar: 10 } });
-    } catch (err) {
-      expect(err).toMatchSnapshot();
-    }
-  });
+		try {
+			await db.insert({ quote: "hello, world!", foo: { bar: 10 } });
+		} catch (err) {
+			expect(err).toMatchSnapshot();
+		}
+	});
 });
 
 describe("lyra", () => {
-  it("should correctly insert and retrieve data", async () => {
-    const db = new Lyra({
-      schema: {
-        example: "string",
-      },
-    });
+	it("should correctly insert and retrieve data", async () => {
+		const db = new Lyra({
+			schema: {
+				example: "string",
+			},
+		});
 
-    const ex1Insert = await db.insert({ example: "The quick, brown, fox" });
-    const ex1Search = await db.search({
-      term: "quick",
-      properties: ["example"],
-    });
+		const ex1Insert = await db.insert({ example: "The quick, brown, fox" });
+		const ex1Search = await db.search({
+			term: "quick",
+			properties: ["example"],
+		});
 
-    expect(ex1Insert.id).toBeDefined();
-    expect(ex1Search.count).toBe(1);
-    expect(ex1Search.elapsed).toBeDefined();
-    expect((ex1Search.hits[0] as any).example).toBe("The quick, brown, fox");
-  });
+		expect(ex1Insert.id).toBeDefined();
+		expect(ex1Search.count).toBe(1);
+		expect(ex1Search.elapsed).toBeDefined();
+		expect((ex1Search.hits[0] as any).example).toBe("The quick, brown, fox");
+	});
 
-  it("should correctly paginate results", async () => {
-    const db = new Lyra({
-      schema: {
-        animal: "string",
-      },
-    });
+	it("should correctly paginate results", async () => {
+		const db = new Lyra({
+			schema: {
+				animal: "string",
+			},
+		});
 
-    await db.insert({ animal: "Quick brown fox" });
-    await db.insert({ animal: "Lazy dog" });
-    await db.insert({ animal: "Jumping penguin" });
-    await db.insert({ animal: "Fast chicken" });
-    await db.insert({ animal: "Fabolous ducks" });
-    await db.insert({ animal: "Fantastic horse" });
+		await db.insert({ animal: "Quick brown fox" });
+		await db.insert({ animal: "Lazy dog" });
+		await db.insert({ animal: "Jumping penguin" });
+		await db.insert({ animal: "Fast chicken" });
+		await db.insert({ animal: "Fabolous ducks" });
+		await db.insert({ animal: "Fantastic horse" });
 
-    const search1 = await db.search({ term: "f", limit: 1, offset: 0 });
-    const search2 = await db.search({ term: "f", limit: 1, offset: 1 });
-    const search3 = await db.search({ term: "f", limit: 1, offset: 2 });
-    const search4 = await db.search({ term: "f", limit: 2, offset: 2 });
+		const search1 = await db.search({ term: "f", limit: 1, offset: 0 });
+		const search2 = await db.search({ term: "f", limit: 1, offset: 1 });
+		const search3 = await db.search({ term: "f", limit: 1, offset: 2 });
+		const search4 = await db.search({ term: "f", limit: 2, offset: 2 });
 
-    expect(search1.count).toBe(4);
-    expect((search1.hits[0] as any).animal).toBe("Quick brown fox");
+		expect(search1.count).toBe(4);
+		expect((search1.hits[0] as any).animal).toBe("Quick brown fox");
 
-    expect(search2.count).toBe(4);
-    expect((search2.hits[0] as any).animal).toBe("Fast chicken");
+		expect(search2.count).toBe(4);
+		expect((search2.hits[0] as any).animal).toBe("Fast chicken");
 
-    expect(search3.count).toBe(4);
-    expect((search3.hits[0] as any).animal).toBe("Fabolous ducks");
+		expect(search3.count).toBe(4);
+		expect((search3.hits[0] as any).animal).toBe("Fabolous ducks");
 
-    expect(search4.count).toBe(4);
-    expect((search4.hits[0] as any).animal).toBe("Fabolous ducks");
-    expect((search4.hits[1] as any).animal).toBe("Fantastic horse");
-  });
+		expect(search4.count).toBe(4);
+		expect((search4.hits[0] as any).animal).toBe("Fabolous ducks");
+		expect((search4.hits[1] as any).animal).toBe("Fantastic horse");
+	});
 
-  it("Should throw an error when searching in non-existing indices", async () => {
-    const db = new Lyra({ schema: { foo: "string", baz: "string" } });
+	it("Should throw an error when searching in non-existing indices", async () => {
+		const db = new Lyra({ schema: { foo: "string", baz: "string" } });
 
-    try {
-      await db.search({
-        term: "foo",
-        properties: ["bar"],
-      });
-    } catch (err) {
-      expect(err).toMatchInlineSnapshot(
-        `"Invalid property name. Expected a wildcard string (\\"*\\") or array containing one of the following properties: foo, baz, but got: bar"`
-      );
-    }
-  });
+		try {
+			await db.search({
+				term: "foo",
+				properties: ["bar"],
+			});
+		} catch (err) {
+			expect(err).toMatchInlineSnapshot(
+				`"Invalid property name. Expected a wildcard string (\\"*\\") or array containing one of the following properties: foo, baz, but got: bar"`
+			);
+		}
+	});
 
-  it("Should correctly remove a document after its insertion", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-      },
-    });
+	it("Should correctly remove a document after its insertion", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+			},
+		});
 
-    const { id: id1 } = await db.insert({
-      quote: "Be yourself; everyone else is already taken.",
-      author: "Oscar Wilde",
-    });
+		const { id: id1 } = await db.insert({
+			quote: "Be yourself; everyone else is already taken.",
+			author: "Oscar Wilde",
+		});
 
-    const { id: id2 } = await db.insert({
-      quote:
-        "To live is the rarest thing in the world. Most people exist, that is all.",
-      author: "Oscar Wilde",
-    });
+		const { id: id2 } = await db.insert({
+			quote:
+				"To live is the rarest thing in the world. Most people exist, that is all.",
+			author: "Oscar Wilde",
+		});
 
-    await db.insert({
-      quote: "So many books, so little time.",
-      author: "Frank Zappa",
-    });
+		await db.insert({
+			quote: "So many books, so little time.",
+			author: "Frank Zappa",
+		});
 
-    const res = await db.delete(id1);
+		const res = await db.delete(id1);
 
-    const searchResult = await db.search({
-      term: "Oscar",
-      properties: ["author"],
-    });
+		const searchResult = await db.search({
+			term: "Oscar",
+			properties: ["author"],
+		});
 
-    expect(res).toBeTruthy();
-    expect(searchResult.count).toBe(1);
-    expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
-    expect((searchResult.hits[0] as any).quote).toBe(
-      "To live is the rarest thing in the world. Most people exist, that is all."
-    );
-    expect((searchResult.hits[0] as any).id).toBe(id2);
-  });
+		expect(res).toBeTruthy();
+		expect(searchResult.count).toBe(1);
+		expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
+		expect((searchResult.hits[0] as any).quote).toBe(
+			"To live is the rarest thing in the world. Most people exist, that is all."
+		);
+		expect((searchResult.hits[0] as any).id).toBe(id2);
+	});
 
-  it("Should preserve identical docs after deletion", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-      },
-    });
+	it("Should preserve identical docs after deletion", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+			},
+		});
 
-    const { id: id1 } = await db.insert({
-      quote: "Be yourself; everyone else is already taken.",
-      author: "Oscar Wilde",
-    });
+		const { id: id1 } = await db.insert({
+			quote: "Be yourself; everyone else is already taken.",
+			author: "Oscar Wilde",
+		});
 
-    const { id: id2 } = await db.insert({
-      quote: "Be yourself; everyone else is already taken.",
-      author: "Oscar Wilde",
-    });
+		const { id: id2 } = await db.insert({
+			quote: "Be yourself; everyone else is already taken.",
+			author: "Oscar Wilde",
+		});
 
-    await db.insert({
-      quote: "So many books, so little time.",
-      author: "Frank Zappa",
-    });
+		await db.insert({
+			quote: "So many books, so little time.",
+			author: "Frank Zappa",
+		});
 
-    const res = await db.delete(id1);
+		const res = await db.delete(id1);
 
-    const searchResult = await db.search({
-      term: "Oscar",
-      properties: ["author"],
-    });
+		const searchResult = await db.search({
+			term: "Oscar",
+			properties: ["author"],
+		});
 
-    const searchResult2 = await db.search({
-      term: "already",
-      properties: ["quote"],
-    });
+		const searchResult2 = await db.search({
+			term: "already",
+			properties: ["quote"],
+		});
 
-    expect(res).toBeTruthy();
-    expect(searchResult.count).toBe(1);
-    expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
-    expect((searchResult.hits[0] as any).quote).toBe(
-      "Be yourself; everyone else is already taken."
-    );
-    expect((searchResult.hits[0] as any).id).toBe(id2);
+		expect(res).toBeTruthy();
+		expect(searchResult.count).toBe(1);
+		expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
+		expect((searchResult.hits[0] as any).quote).toBe(
+			"Be yourself; everyone else is already taken."
+		);
+		expect((searchResult.hits[0] as any).id).toBe(id2);
 
-    expect(searchResult2.count).toBe(1);
-    expect((searchResult2.hits[0] as any).author).toBe("Oscar Wilde");
-    expect((searchResult2.hits[0] as any).quote).toBe(
-      "Be yourself; everyone else is already taken."
-    );
-    expect((searchResult2.hits[0] as any).id).toBe(id2);
-  });
+		expect(searchResult2.count).toBe(1);
+		expect((searchResult2.hits[0] as any).author).toBe("Oscar Wilde");
+		expect((searchResult2.hits[0] as any).quote).toBe(
+			"Be yourself; everyone else is already taken."
+		);
+		expect((searchResult2.hits[0] as any).id).toBe(id2);
+	});
 
-  it("Should be able to insert documens with non-searchable fields", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-        isFavorite: "boolean",
-        rating: "number",
-      },
-    });
+	it("Should be able to insert documens with non-searchable fields", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+				isFavorite: "boolean",
+				rating: "number",
+			},
+		});
 
-    await db.insert({
-      quote: "Be yourself; everyone else is already taken.",
-      author: "Oscar Wilde",
-      isFavorite: false,
-      rating: 4,
-    });
+		await db.insert({
+			quote: "Be yourself; everyone else is already taken.",
+			author: "Oscar Wilde",
+			isFavorite: false,
+			rating: 4,
+		});
 
-    await db.insert({
-      quote: "So many books, so little time.",
-      author: "Frank Zappa",
-      isFavorite: true,
-      rating: 5,
-    });
+		await db.insert({
+			quote: "So many books, so little time.",
+			author: "Frank Zappa",
+			isFavorite: true,
+			rating: 5,
+		});
 
-    const search = await db.search({
-      term: "frank",
-    });
+		const search = await db.search({
+			term: "frank",
+		});
 
-    expect(search.count).toBe(1);
-    expect((search.hits[0] as any).author).toBe("Frank Zappa");
-  });
+		expect(search.count).toBe(1);
+		expect((search.hits[0] as any).author).toBe("Frank Zappa");
+	});
 
-  it("Should exact match", async () => {
-    const db = new Lyra({
-      schema: {
-        author: "string",
-        quote: "string",
-      },
-    });
+	it("Should exact match", async () => {
+		const db = new Lyra({
+			schema: {
+				author: "string",
+				quote: "string",
+			},
+		});
 
-    await db.insert({
-      quote: "Be yourself; everyone else is already taken.",
-      author: "Oscar Wilde",
-    });
+		await db.insert({
+			quote: "Be yourself; everyone else is already taken.",
+			author: "Oscar Wilde",
+		});
 
-    const partialSearch = await db.search({
-      term: "alr",
-      exact: true,
-    });
+		const partialSearch = await db.search({
+			term: "alr",
+			exact: true,
+		});
 
-    expect(partialSearch.count).toBe(0);
+		expect(partialSearch.count).toBe(0);
 
-    const exactSearch = await db.search({
-      term: "already",
-      exact: true,
-    });
+		const exactSearch = await db.search({
+			term: "already",
+			exact: true,
+		});
 
-    expect(exactSearch.count).toBe(1);
-    expect((exactSearch.hits[0] as any).quote).toBe(
-      "Be yourself; everyone else is already taken."
-    );
-    expect((exactSearch.hits[0] as any).author).toBe("Oscar Wilde");
-  });
+		expect(exactSearch.count).toBe(1);
+		expect((exactSearch.hits[0] as any).quote).toBe(
+			"Be yourself; everyone else is already taken."
+		);
+		expect((exactSearch.hits[0] as any).author).toBe("Oscar Wilde");
+	});
 
-  it("Shouldn't tolerate typos", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-      },
-    });
+	it("Shouldn't tolerate typos", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+			},
+		});
 
-    await db.insert({
-      quote:
-        "Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
-      author: "Sara A. Lourie",
-    });
+		await db.insert({
+			quote:
+				"Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
+			author: "Sara A. Lourie",
+		});
 
-    const search = await db.search({
-      term: "seahrse",
-      tolerance: 0,
-    });
+		const search = await db.search({
+			term: "seahrse",
+			tolerance: 0,
+		});
 
-    expect(search.count).toBe(0);
-  });
+		expect(search.count).toBe(0);
+	});
 
-  it("Should tolerate typos", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-      },
-    });
+	it("Should tolerate typos", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+			},
+		});
 
-    await db.insert({
-      quote:
-        "Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
-      author: "Sara A. Lourie",
-    });
+		await db.insert({
+			quote:
+				"Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
+			author: "Sara A. Lourie",
+		});
 
-    await db.insert({
-      quote:
-        "Seahorses look mythical, like dragons, but these magnificent shy creatures are real.",
-      author: "Jennifer Keats Curtis",
-    });
+		await db.insert({
+			quote:
+				"Seahorses look mythical, like dragons, but these magnificent shy creatures are real.",
+			author: "Jennifer Keats Curtis",
+		});
 
-    const tolerantSearch = await db.search({
-      term: "seahrse",
-      tolerance: 1,
-    });
+		const tolerantSearch = await db.search({
+			term: "seahrse",
+			tolerance: 1,
+		});
 
-    expect(tolerantSearch.count).toBe(2);
+		expect(tolerantSearch.count).toBe(2);
 
-    const moreTolerantSearch = await db.search({
-      term: "sahrse",
-      tolerance: 3,
-    });
+		const moreTolerantSearch = await db.search({
+			term: "sahrse",
+			tolerance: 3,
+		});
 
-    expect(moreTolerantSearch.count).toBe(2);
-  });
+		expect(moreTolerantSearch.count).toBe(2);
+	});
+
+	it("Should support nested properties", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: {
+					name: "string",
+					surname: "string",
+				},
+			},
+		});
+
+		await db.insert({
+			quote: "Harry Potter, the boy who lived, come to die. Avada kedavra.",
+			author: {
+				name: "Tom",
+				surname: "Riddle",
+			},
+		});
+
+		await db.insert({
+			quote: "I am Homer Simpson.",
+			author: {
+				name: "Homer",
+				surname: "Simpson",
+			},
+		});
+
+		const resultAuthorSurname = await db.search({
+			term: "Riddle",
+			properties: ["author.surname"],
+		});
+
+		const resultAuthorName = await db.search({
+			term: "Riddle",
+			properties: ["author.name"],
+		});
+
+		const resultSimpsonQuote = await db.search({
+			term: "Homer",
+			properties: ["quote"],
+		});
+
+		const resultSimpsonAuthorName = await db.search({
+			term: "Homer",
+			properties: ["author.name"],
+		});
+
+		expect(resultSimpsonAuthorName.count).toBe(1);
+		expect(resultSimpsonQuote.count).toBe(1);
+		expect(resultAuthorSurname.count).toBe(1);
+		expect(resultAuthorName.count).toBe(0);
+	});
 });

--- a/packages/lyra/tests/lyra.test.ts
+++ b/packages/lyra/tests/lyra.test.ts
@@ -61,7 +61,8 @@ describe("checkInsertDocSchema", () => {
     ).toBeDefined();
 
     try {
-      await db.insert({ quote: "hello, world!", author: true } as any);
+      // @ts-expect-error
+      await db.insert({ quote: "hello, world!", author: true });
     } catch (err) {
       expect(err).toMatchSnapshot();
     }
@@ -69,14 +70,16 @@ describe("checkInsertDocSchema", () => {
     try {
       await db.insert({
         quote: "hello, world!",
+        // @ts-expect-error
         authors: "author should be singular",
-      } as any);
+      });
     } catch (err) {
       expect(err).toMatchSnapshot();
     }
 
     try {
-      await db.insert({ quote: "hello, world!", foo: { bar: 10 } } as any);
+      // @ts-expect-error
+      await db.insert({ quote: "hello, world!", foo: { bar: 10 } });
     } catch (err) {
       expect(err).toMatchSnapshot();
     }

--- a/packages/lyra/tests/lyra.test.ts
+++ b/packages/lyra/tests/lyra.test.ts
@@ -1,418 +1,418 @@
 import { Lyra } from "../src/lyra";
 
 function getId({ id }: { id: string }) {
-  return id;
+	return id;
 }
 
 describe("defaultLanguage", () => {
-  it("should throw an error if the desired language is not supported", () => {
-    try {
-      new Lyra({
-        schema: {},
-        // @ts-expect-error latin is not supported
-        defaultLanguage: "latin",
-      });
-    } catch (e) {
-      expect(e).toMatchSnapshot();
-    }
-  });
+	it("should throw an error if the desired language is not supported", () => {
+		try {
+			new Lyra({
+				schema: {},
+				// @ts-expect-error latin is not supported
+				defaultLanguage: "latin",
+			});
+		} catch (e) {
+			expect(e).toMatchSnapshot();
+		}
+	});
 
-  it("should throw an error if the desired language is not supported during insertion", async () => {
-    try {
-      const db = new Lyra({
-        schema: { foo: "string" },
-      });
+	it("should throw an error if the desired language is not supported during insertion", async () => {
+		try {
+			const db = new Lyra({
+				schema: { foo: "string" },
+			});
 
-      await db.insert(
-        {
-          foo: "bar",
-        },
-        // @ts-expect-error latin is not supported
-        "latin"
-      );
-    } catch (e) {
-      expect(e).toMatchSnapshot();
-    }
-  });
+			await db.insert(
+				{
+					foo: "bar",
+				},
+				// @ts-expect-error latin is not supported
+				"latin"
+			);
+		} catch (e) {
+			expect(e).toMatchSnapshot();
+		}
+	});
 
-  it("should not throw if if the language is supported", () => {
-    try {
-      new Lyra({
-        schema: {},
-        defaultLanguage: "portugese",
-      });
-    } catch (e) {
-      expect(e).toBeUndefined();
-    }
-  });
+	it("should not throw if if the language is supported", () => {
+		try {
+			new Lyra({
+				schema: {},
+				defaultLanguage: "portugese",
+			});
+		} catch (e) {
+			expect(e).toBeUndefined();
+		}
+	});
 });
 
 describe("checkInsertDocSchema", () => {
-  it("should compare the inserted doc with the schema definition", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-      },
-    });
+	it("should compare the inserted doc with the schema definition", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+			},
+		});
 
-    expect(
-      await db.insert({ quote: "hello, world!", author: "me" }).then(getId)
-    ).toBeDefined();
+		expect(
+			await db.insert({ quote: "hello, world!", author: "me" }).then(getId)
+		).toBeDefined();
 
-    try {
-      await db.insert({ quote: "hello, world!", author: true });
-    } catch (err) {
-      expect(err).toMatchSnapshot();
-    }
+		try {
+			await db.insert({ quote: "hello, world!", author: true } as any);
+		} catch (err) {
+			expect(err).toMatchSnapshot();
+		}
 
-    try {
-      await db.insert({
-        quote: "hello, world!",
-        authors: "author should be singular",
-      });
-    } catch (err) {
-      expect(err).toMatchSnapshot();
-    }
+		try {
+			await db.insert({
+				quote: "hello, world!",
+				authors: "author should be singular",
+			} as any);
+		} catch (err) {
+			expect(err).toMatchSnapshot();
+		}
 
-    try {
-      await db.insert({ quote: "hello, world!", foo: { bar: 10 } });
-    } catch (err) {
-      expect(err).toMatchSnapshot();
-    }
-  });
+		try {
+			await db.insert({ quote: "hello, world!", foo: { bar: 10 } } as any);
+		} catch (err) {
+			expect(err).toMatchSnapshot();
+		}
+	});
 });
 
 describe("lyra", () => {
-  it("should correctly insert and retrieve data", async () => {
-    const db = new Lyra({
-      schema: {
-        example: "string",
-      },
-    });
+	it("should correctly insert and retrieve data", async () => {
+		const db = new Lyra({
+			schema: {
+				example: "string",
+			},
+		});
 
-    const ex1Insert = await db.insert({ example: "The quick, brown, fox" });
-    const ex1Search = await db.search({
-      term: "quick",
-      properties: ["example"],
-    });
+		const ex1Insert = await db.insert({ example: "The quick, brown, fox" });
+		const ex1Search = await db.search({
+			term: "quick",
+			properties: ["example"],
+		});
 
-    expect(ex1Insert.id).toBeDefined();
-    expect(ex1Search.count).toBe(1);
-    expect(ex1Search.elapsed).toBeDefined();
-    expect((ex1Search.hits[0] as any).example).toBe("The quick, brown, fox");
-  });
+		expect(ex1Insert.id).toBeDefined();
+		expect(ex1Search.count).toBe(1);
+		expect(ex1Search.elapsed).toBeDefined();
+		expect((ex1Search.hits[0] as any).example).toBe("The quick, brown, fox");
+	});
 
-  it("should correctly paginate results", async () => {
-    const db = new Lyra({
-      schema: {
-        animal: "string",
-      },
-    });
+	it("should correctly paginate results", async () => {
+		const db = new Lyra({
+			schema: {
+				animal: "string",
+			},
+		});
 
-    await db.insert({ animal: "Quick brown fox" });
-    await db.insert({ animal: "Lazy dog" });
-    await db.insert({ animal: "Jumping penguin" });
-    await db.insert({ animal: "Fast chicken" });
-    await db.insert({ animal: "Fabolous ducks" });
-    await db.insert({ animal: "Fantastic horse" });
+		await db.insert({ animal: "Quick brown fox" });
+		await db.insert({ animal: "Lazy dog" });
+		await db.insert({ animal: "Jumping penguin" });
+		await db.insert({ animal: "Fast chicken" });
+		await db.insert({ animal: "Fabolous ducks" });
+		await db.insert({ animal: "Fantastic horse" });
 
-    const search1 = await db.search({ term: "f", limit: 1, offset: 0 });
-    const search2 = await db.search({ term: "f", limit: 1, offset: 1 });
-    const search3 = await db.search({ term: "f", limit: 1, offset: 2 });
-    const search4 = await db.search({ term: "f", limit: 2, offset: 2 });
+		const search1 = await db.search({ term: "f", limit: 1, offset: 0 });
+		const search2 = await db.search({ term: "f", limit: 1, offset: 1 });
+		const search3 = await db.search({ term: "f", limit: 1, offset: 2 });
+		const search4 = await db.search({ term: "f", limit: 2, offset: 2 });
 
-    expect(search1.count).toBe(4);
-    expect((search1.hits[0] as any).animal).toBe("Quick brown fox");
+		expect(search1.count).toBe(4);
+		expect((search1.hits[0] as any).animal).toBe("Quick brown fox");
 
-    expect(search2.count).toBe(4);
-    expect((search2.hits[0] as any).animal).toBe("Fast chicken");
+		expect(search2.count).toBe(4);
+		expect((search2.hits[0] as any).animal).toBe("Fast chicken");
 
-    expect(search3.count).toBe(4);
-    expect((search3.hits[0] as any).animal).toBe("Fabolous ducks");
+		expect(search3.count).toBe(4);
+		expect((search3.hits[0] as any).animal).toBe("Fabolous ducks");
 
-    expect(search4.count).toBe(4);
-    expect((search4.hits[0] as any).animal).toBe("Fabolous ducks");
-    expect((search4.hits[1] as any).animal).toBe("Fantastic horse");
-  });
+		expect(search4.count).toBe(4);
+		expect((search4.hits[0] as any).animal).toBe("Fabolous ducks");
+		expect((search4.hits[1] as any).animal).toBe("Fantastic horse");
+	});
 
-  it("Should throw an error when searching in non-existing indices", async () => {
-    const db = new Lyra({ schema: { foo: "string", baz: "string" } });
+	it("Should throw an error when searching in non-existing indices", async () => {
+		const db = new Lyra({ schema: { foo: "string", baz: "string" } });
 
-    try {
-      await db.search({
-        term: "foo",
-        properties: ["bar"],
-      });
-    } catch (err) {
-      expect(err).toMatchInlineSnapshot(
-        `"Invalid property name. Expected a wildcard string (\\"*\\") or array containing one of the following properties: foo, baz, but got: bar"`
-      );
-    }
-  });
+		try {
+			await db.search({
+				term: "foo",
+				properties: ["bar"],
+			});
+		} catch (err) {
+			expect(err).toMatchInlineSnapshot(
+				`"Invalid property name. Expected a wildcard string (\\"*\\") or array containing one of the following properties: foo, baz, but got: bar"`
+			);
+		}
+	});
 
-  it("Should correctly remove a document after its insertion", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-      },
-    });
+	it("Should correctly remove a document after its insertion", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+			},
+		});
 
-    const { id: id1 } = await db.insert({
-      quote: "Be yourself; everyone else is already taken.",
-      author: "Oscar Wilde",
-    });
+		const { id: id1 } = await db.insert({
+			quote: "Be yourself; everyone else is already taken.",
+			author: "Oscar Wilde",
+		});
 
-    const { id: id2 } = await db.insert({
-      quote:
-        "To live is the rarest thing in the world. Most people exist, that is all.",
-      author: "Oscar Wilde",
-    });
+		const { id: id2 } = await db.insert({
+			quote:
+				"To live is the rarest thing in the world. Most people exist, that is all.",
+			author: "Oscar Wilde",
+		});
 
-    await db.insert({
-      quote: "So many books, so little time.",
-      author: "Frank Zappa",
-    });
+		await db.insert({
+			quote: "So many books, so little time.",
+			author: "Frank Zappa",
+		});
 
-    const res = await db.delete(id1);
+		const res = await db.delete(id1);
 
-    const searchResult = await db.search({
-      term: "Oscar",
-      properties: ["author"],
-    });
+		const searchResult = await db.search({
+			term: "Oscar",
+			properties: ["author"],
+		});
 
-    expect(res).toBeTruthy();
-    expect(searchResult.count).toBe(1);
-    expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
-    expect((searchResult.hits[0] as any).quote).toBe(
-      "To live is the rarest thing in the world. Most people exist, that is all."
-    );
-    expect((searchResult.hits[0] as any).id).toBe(id2);
-  });
+		expect(res).toBeTruthy();
+		expect(searchResult.count).toBe(1);
+		expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
+		expect((searchResult.hits[0] as any).quote).toBe(
+			"To live is the rarest thing in the world. Most people exist, that is all."
+		);
+		expect((searchResult.hits[0] as any).id).toBe(id2);
+	});
 
-  it("Should preserve identical docs after deletion", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-      },
-    });
+	it("Should preserve identical docs after deletion", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+			},
+		});
 
-    const { id: id1 } = await db.insert({
-      quote: "Be yourself; everyone else is already taken.",
-      author: "Oscar Wilde",
-    });
+		const { id: id1 } = await db.insert({
+			quote: "Be yourself; everyone else is already taken.",
+			author: "Oscar Wilde",
+		});
 
-    const { id: id2 } = await db.insert({
-      quote: "Be yourself; everyone else is already taken.",
-      author: "Oscar Wilde",
-    });
+		const { id: id2 } = await db.insert({
+			quote: "Be yourself; everyone else is already taken.",
+			author: "Oscar Wilde",
+		});
 
-    await db.insert({
-      quote: "So many books, so little time.",
-      author: "Frank Zappa",
-    });
+		await db.insert({
+			quote: "So many books, so little time.",
+			author: "Frank Zappa",
+		});
 
-    const res = await db.delete(id1);
+		const res = await db.delete(id1);
 
-    const searchResult = await db.search({
-      term: "Oscar",
-      properties: ["author"],
-    });
+		const searchResult = await db.search({
+			term: "Oscar",
+			properties: ["author"],
+		});
 
-    const searchResult2 = await db.search({
-      term: "already",
-      properties: ["quote"],
-    });
+		const searchResult2 = await db.search({
+			term: "already",
+			properties: ["quote"],
+		});
 
-    expect(res).toBeTruthy();
-    expect(searchResult.count).toBe(1);
-    expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
-    expect((searchResult.hits[0] as any).quote).toBe(
-      "Be yourself; everyone else is already taken."
-    );
-    expect((searchResult.hits[0] as any).id).toBe(id2);
+		expect(res).toBeTruthy();
+		expect(searchResult.count).toBe(1);
+		expect((searchResult.hits[0] as any).author).toBe("Oscar Wilde");
+		expect((searchResult.hits[0] as any).quote).toBe(
+			"Be yourself; everyone else is already taken."
+		);
+		expect((searchResult.hits[0] as any).id).toBe(id2);
 
-    expect(searchResult2.count).toBe(1);
-    expect((searchResult2.hits[0] as any).author).toBe("Oscar Wilde");
-    expect((searchResult2.hits[0] as any).quote).toBe(
-      "Be yourself; everyone else is already taken."
-    );
-    expect((searchResult2.hits[0] as any).id).toBe(id2);
-  });
+		expect(searchResult2.count).toBe(1);
+		expect((searchResult2.hits[0] as any).author).toBe("Oscar Wilde");
+		expect((searchResult2.hits[0] as any).quote).toBe(
+			"Be yourself; everyone else is already taken."
+		);
+		expect((searchResult2.hits[0] as any).id).toBe(id2);
+	});
 
-  it("Should be able to insert documens with non-searchable fields", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-        isFavorite: "boolean",
-        rating: "number",
-      },
-    });
+	it("Should be able to insert documens with non-searchable fields", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+				isFavorite: "boolean",
+				rating: "number",
+			},
+		});
 
-    await db.insert({
-      quote: "Be yourself; everyone else is already taken.",
-      author: "Oscar Wilde",
-      isFavorite: false,
-      rating: 4,
-    });
+		await db.insert({
+			quote: "Be yourself; everyone else is already taken.",
+			author: "Oscar Wilde",
+			isFavorite: false,
+			rating: 4,
+		});
 
-    await db.insert({
-      quote: "So many books, so little time.",
-      author: "Frank Zappa",
-      isFavorite: true,
-      rating: 5,
-    });
+		await db.insert({
+			quote: "So many books, so little time.",
+			author: "Frank Zappa",
+			isFavorite: true,
+			rating: 5,
+		});
 
-    const search = await db.search({
-      term: "frank",
-    });
+		const search = await db.search({
+			term: "frank",
+		});
 
-    expect(search.count).toBe(1);
-    expect((search.hits[0] as any).author).toBe("Frank Zappa");
-  });
+		expect(search.count).toBe(1);
+		expect((search.hits[0] as any).author).toBe("Frank Zappa");
+	});
 
-  it("Should exact match", async () => {
-    const db = new Lyra({
-      schema: {
-        author: "string",
-        quote: "string",
-      },
-    });
+	it("Should exact match", async () => {
+		const db = new Lyra({
+			schema: {
+				author: "string",
+				quote: "string",
+			},
+		});
 
-    await db.insert({
-      quote: "Be yourself; everyone else is already taken.",
-      author: "Oscar Wilde",
-    });
+		await db.insert({
+			quote: "Be yourself; everyone else is already taken.",
+			author: "Oscar Wilde",
+		});
 
-    const partialSearch = await db.search({
-      term: "alr",
-      exact: true,
-    });
+		const partialSearch = await db.search({
+			term: "alr",
+			exact: true,
+		});
 
-    expect(partialSearch.count).toBe(0);
+		expect(partialSearch.count).toBe(0);
 
-    const exactSearch = await db.search({
-      term: "already",
-      exact: true,
-    });
+		const exactSearch = await db.search({
+			term: "already",
+			exact: true,
+		});
 
-    expect(exactSearch.count).toBe(1);
-    expect((exactSearch.hits[0] as any).quote).toBe(
-      "Be yourself; everyone else is already taken."
-    );
-    expect((exactSearch.hits[0] as any).author).toBe("Oscar Wilde");
-  });
+		expect(exactSearch.count).toBe(1);
+		expect((exactSearch.hits[0] as any).quote).toBe(
+			"Be yourself; everyone else is already taken."
+		);
+		expect((exactSearch.hits[0] as any).author).toBe("Oscar Wilde");
+	});
 
-  it("Shouldn't tolerate typos", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-      },
-    });
+	it("Shouldn't tolerate typos", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+			},
+		});
 
-    await db.insert({
-      quote:
-        "Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
-      author: "Sara A. Lourie",
-    });
+		await db.insert({
+			quote:
+				"Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
+			author: "Sara A. Lourie",
+		});
 
-    const search = await db.search({
-      term: "seahrse",
-      tolerance: 0,
-    });
+		const search = await db.search({
+			term: "seahrse",
+			tolerance: 0,
+		});
 
-    expect(search.count).toBe(0);
-  });
+		expect(search.count).toBe(0);
+	});
 
-  it("Should tolerate typos", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: "string",
-      },
-    });
+	it("Should tolerate typos", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: "string",
+			},
+		});
 
-    await db.insert({
-      quote:
-        "Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
-      author: "Sara A. Lourie",
-    });
+		await db.insert({
+			quote:
+				"Absolutely captivating creatures, seahorses seem like a product of myth and imagination rather than of nature.",
+			author: "Sara A. Lourie",
+		});
 
-    await db.insert({
-      quote:
-        "Seahorses look mythical, like dragons, but these magnificent shy creatures are real.",
-      author: "Jennifer Keats Curtis",
-    });
+		await db.insert({
+			quote:
+				"Seahorses look mythical, like dragons, but these magnificent shy creatures are real.",
+			author: "Jennifer Keats Curtis",
+		});
 
-    const tolerantSearch = await db.search({
-      term: "seahrse",
-      tolerance: 1,
-    });
+		const tolerantSearch = await db.search({
+			term: "seahrse",
+			tolerance: 1,
+		});
 
-    expect(tolerantSearch.count).toBe(2);
+		expect(tolerantSearch.count).toBe(2);
 
-    const moreTolerantSearch = await db.search({
-      term: "sahrse",
-      tolerance: 3,
-    });
+		const moreTolerantSearch = await db.search({
+			term: "sahrse",
+			tolerance: 3,
+		});
 
-    expect(moreTolerantSearch.count).toBe(2);
-  });
+		expect(moreTolerantSearch.count).toBe(2);
+	});
 
-  it("Should support nested properties", async () => {
-    const db = new Lyra({
-      schema: {
-        quote: "string",
-        author: {
-          name: "string",
-          surname: "string",
-        },
-      },
-    });
+	it("Should support nested properties", async () => {
+		const db = new Lyra({
+			schema: {
+				quote: "string",
+				author: {
+					name: "string",
+					surname: "string",
+				},
+			},
+		});
 
-    await db.insert({
-      quote: "Harry Potter, the boy who lived, come to die. Avada kedavra.",
-      author: {
-        name: "Tom",
-        surname: "Riddle",
-      },
-    });
+		await db.insert({
+			quote: "Harry Potter, the boy who lived, come to die. Avada kedavra.",
+			author: {
+				name: "Tom",
+				surname: "Riddle",
+			},
+		});
 
-    await db.insert({
-      quote: "I am Homer Simpson.",
-      author: {
-        name: "Homer",
-        surname: "Simpson",
-      },
-    });
+		await db.insert({
+			quote: "I am Homer Simpson.",
+			author: {
+				name: "Homer",
+				surname: "Simpson",
+			},
+		});
 
-    const resultAuthorSurname = await db.search({
-      term: "Riddle",
-      properties: ["author.surname"],
-    });
+		const resultAuthorSurname = await db.search({
+			term: "Riddle",
+			properties: ["author.surname"],
+		});
 
-    const resultAuthorName = await db.search({
-      term: "Riddle",
-      properties: ["author.name"],
-    });
+		const resultAuthorName = await db.search({
+			term: "Riddle",
+			properties: ["author.name"],
+		});
 
-    const resultSimpsonQuote = await db.search({
-      term: "Homer",
-      properties: ["quote"],
-    });
+		const resultSimpsonQuote = await db.search({
+			term: "Homer",
+			properties: ["quote"],
+		});
 
-    const resultSimpsonAuthorName = await db.search({
-      term: "Homer",
-      properties: ["author.name"],
-    });
+		const resultSimpsonAuthorName = await db.search({
+			term: "Homer",
+			properties: ["author.name"],
+		});
 
-    expect(resultSimpsonAuthorName.count).toBe(1);
-    expect(resultSimpsonQuote.count).toBe(1);
-    expect(resultAuthorSurname.count).toBe(1);
-    expect(resultAuthorName.count).toBe(0);
-  });
+		expect(resultSimpsonAuthorName.count).toBe(1);
+		expect(resultSimpsonQuote.count).toBe(1);
+		expect(resultAuthorSurname.count).toBe(1);
+		expect(resultAuthorName.count).toBe(0);
+	});
 });


### PR DESCRIPTION
As per https://github.com/nearform/lyra/issues/14#issuecomment-1186160234 this PR aims to  type the insert method so the developer will know at compile time if the document inserted does not match the schema.

Code coverage:

File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s   
-----------------|---------|----------|---------|---------|---------------------
All files        |   87.95 |    72.82 |      90 |   89.04 |                     
 src             |   84.68 |    66.07 |   84.61 |    85.2 |                     
  errors.ts      |    82.6 |      100 |      50 |      75 | 8,20,23,26          
  levenshtein.ts |   91.66 |       60 |     100 |     100 | 2-3                 
  lyra.ts        |   93.69 |    78.78 |     100 |   94.54 | 118,155-158,173,184 
  stemmer.ts     |   30.76 |    18.18 |     100 |   30.76 | 22-23,28-49,56      
  tokenizer.ts   |     100 |      100 |     100 |     100 |                     
  utils.ts       |   94.73 |    83.33 |     100 |   94.73 | 30                  
 src/prefix-tree |   95.55 |    83.33 |     100 |    97.7 |                     
  node.ts        |     100 |      100 |     100 |     100 |                     
  trie.ts        |   94.59 |    83.33 |     100 |   97.18 | 121,146             