### PR TITLE
Prevent undefined elements

### DIFF
--- a/packages/lyra/src/lyra.ts
+++ b/packages/lyra/src/lyra.ts
@@ -154,9 +154,11 @@ export class Lyra<TSchema extends PropertiesSchema = PropertiesSchema> {
       }
     }
 
+    const hits = results.filter(Boolean);
+
     return {
       elapsed: formatNanoseconds(getNanosecondsTime() - timeStart),
-      hits: results,
+      hits,
       count: totalResults,
     };
   }

--- a/packages/lyra/src/lyra.ts
+++ b/packages/lyra/src/lyra.ts
@@ -113,23 +113,23 @@ export class Lyra<TSchema extends PropertiesSchema = PropertiesSchema> {
     const results: RetrievedDoc<TSchema>[] = Array.from({
       length: limit,
     });
-    let totalResults = 0;
+    let count = 0;
 
     const timeStart = getNanosecondsTime();
 
     let i = 0;
     let j = 0;
 
-    for (const token of tokens) {
+    for (const term of tokens) {
       for (const index of indices) {
         const documentIDs = await this.getDocumentIDsFromSearch({
           ...params,
-          index: index,
-          term: token,
-          exact: exact,
+          index,
+          term,
+          exact,
         });
 
-        totalResults += documentIDs.size;
+        count += documentIDs.size;
 
         if (i >= limit) {
           break;
@@ -159,7 +159,7 @@ export class Lyra<TSchema extends PropertiesSchema = PropertiesSchema> {
     return {
       elapsed: formatNanoseconds(getNanosecondsTime() - timeStart),
       hits,
-      count: totalResults,
+      count,
     };
   }
 


### PR DESCRIPTION
This PR fixes #29.

The solution is to add, before the return statement, a filter by `Boolean`, so undefined elements are filtered.

After doing several benchmarks between `filter` method, `dynamic array`, and the current solution, the result makes the filter method more performant.

Let me show you some data.

### 100K elements

> Inserting **100K** elements, search something, and limit by _1_.

**Current fixed allocation array**

```js
{ elapsed: '80μs', hits: [ undefined ], count: 0 } { timeSpent: '1072ms' }
```

**Dynamic allocation array**

```js
{ elapsed: '82μs', hits: [], count: 0 } { timeSpent: '1117ms' }
```

**Filtering results**

```js
{ elapsed: '75μs', hits: [], count: 0 } { timeSpent: '1080ms' }
```

### 1M elements

> Inserting **1M** elements, search something, and limit by _10_.

```js
{
  elapsed: '79μs',
  hits: [
    undefined, undefined,
    undefined, undefined,
    undefined, undefined,
    undefined, undefined,
    undefined, undefined
  ],
  count: 0
} { timeSpent: '11836ms' }
```

**Dynamic allocation array**

```js
{ elapsed: '88μs', hits: [], count: 0 } { timeSpent: '11822ms' }
```

**Filtering results**

```js
{ elapsed: '81μs', hits: [], count: 0 } { timeSpent: '11068ms' }
```

I also cleaned some variable names, (more readable in my opinion) by having them with the same name as the props returned in the function.
