### PR TITLE
Add exact param in remove doc by word method

### DIFF
--- a/packages/lyra/src/prefix-tree/trie.ts
+++ b/packages/lyra/src/prefix-tree/trie.ts
@@ -107,14 +107,14 @@ export class Trie {
     return output;
   }
 
-  removeDocByWord(word: string, docID: string): boolean {
+  removeDocByWord(word: string, docID: string, exact = false): boolean {
     const root = this.root;
     if (!word) return false;
 
     function removeWord(node: TrieNode, _word: string, docID: string): boolean {
       const [nodeWord /**_docs*/] = node.getWord();
 
-      if (node.end && nodeWord === word) {
+      if (node.end || (exact && node.end && nodeWord === word)) {
         node.removeDoc(docID);
 
         if (node.children?.size) {

--- a/packages/lyra/tests/lyra.test.ts
+++ b/packages/lyra/tests/lyra.test.ts
@@ -195,6 +195,51 @@ describe("lyra", () => {
     expect(searchResult.hits[0].id).toBe(id2);
   });
 
+  it("Shouldn't returns deleted documents", async () => {
+    const db = new Lyra({
+      schema: {
+        txt: "string",
+      },
+      stemming: false,
+    });
+
+    await db.insert({ txt: "stelle" });
+    await db.insert({ txt: "stellle" });
+    await db.insert({ txt: "scelte" });
+
+    const search = await db.search({ term: "stelle" });
+
+    const id = search.hits[0].id;
+
+    await db.delete(id);
+
+    const serach2 = await db.search({ term: "stelle" });
+
+    expect(serach2.count).toBe(1);
+  });
+
+  it("Shouldn't affects other document when deleted one", async () => {
+    const db = new Lyra({
+      schema: {
+        txt: "string",
+      },
+      stemming: false,
+    });
+
+    await db.insert({ txt: "abc" });
+    await db.insert({ txt: "abc" });
+    await db.insert({ txt: "abcd" });
+
+    const search = await db.search({ term: "abc", exact: true });
+
+    const id = search.hits[0].id;
+    await db.delete(id);
+
+    const search2 = await db.search({ term: "abc" });
+
+    expect(search2.count).toBe(1);
+  });
+
   it("Should preserve identical docs after deletion", async () => {
     const db = new Lyra({
       schema: {


### PR DESCRIPTION
This PR fixes #39 and #40.

I've implemented a new param in the `removeDocByWord` method used in `remove` method to prevent removing words that not exactly matches the document's word.

I also added 2 cases to the tests.