### PR TITLE
Prevent exact match in ended node

### DIFF
--- a/packages/lyra/src/prefix-tree/trie.ts
+++ b/packages/lyra/src/prefix-tree/trie.ts
@@ -63,6 +63,18 @@ export class Trie {
       }
     }
 
+    const [word, docIDs] = node.getWord();
+
+    if (exact && word === term) {
+      output[word] = new Set();
+
+      for (const doc of docIDs) {
+        output[word].add(doc);
+      }
+
+      return output;
+    }
+
     findAllWords(node, output);
 
     function findAllWords(_node: TrieNode, _output: FindResult) {

--- a/packages/lyra/src/prefix-tree/trie.ts
+++ b/packages/lyra/src/prefix-tree/trie.ts
@@ -63,27 +63,34 @@ export class Trie {
       }
     }
 
+    // avoid the recursive call if the word is the same as the term
     const [word, docIDs] = node.getWord();
 
     if (exact && word === term) {
       output[word] = new Set();
 
-      for (const doc of docIDs) {
-        output[word].add(doc);
-      }
+      handleOutput(word, docIDs, output);
 
       return output;
     }
 
     findAllWords(node, output);
 
+    function handleOutput(
+      word: string,
+      docIDs: Set<string>,
+      _output: FindResult
+    ): void {
+      if (docIDs.size) {
+        for (const doc of docIDs) {
+          _output[word] && _output[word].add(doc);
+        }
+      }
+    }
+
     function findAllWords(_node: TrieNode, _output: FindResult) {
       if (_node.end) {
         const [word, docIDs] = _node.getWord();
-
-        if (exact && word !== term) {
-          return output;
-        }
 
         if (!(word in _output)) {
           if (tolerance) {
@@ -103,12 +110,7 @@ export class Trie {
           }
         }
 
-        if (docIDs?.size) {
-          for (const doc of docIDs) {
-            // check if _output[word] exists and then add the doc to it
-            _output[word] && _output[word].add(doc);
-          }
-        }
+        handleOutput(word, docIDs, _output);
       }
 
       for (const childNode of _node.children?.values() ?? []) {

--- a/packages/lyra/tests/lyra.test.ts
+++ b/packages/lyra/tests/lyra.test.ts
@@ -229,8 +229,10 @@ describe("lyra", () => {
     await db.insert({ txt: "abc" });
     await db.insert({ txt: "abc" });
     await db.insert({ txt: "abcd" });
+    await db.insert({ txt: "abc" });
+
     await db.insert({ txt: "abcd" });
-    await db.insert({ txt: "abcd" });
+    await db.insert({ txt: "abc" });
     await db.insert({ txt: "abcd" });
 
     const search = await db.search({ term: "abc", exact: true });
@@ -241,7 +243,7 @@ describe("lyra", () => {
     const search2 = await db.search({ term: "abc", exact: true });
 
     expect(search2.hits.every(({ id: docID }) => docID !== id)).toBe(true);
-    expect(search2.count).toBe(1);
+    expect(search2.count).toBe(3);
   });
 
   it("Should preserve identical docs after deletion", async () => {

--- a/packages/lyra/tests/lyra.test.ts
+++ b/packages/lyra/tests/lyra.test.ts
@@ -229,14 +229,18 @@ describe("lyra", () => {
     await db.insert({ txt: "abc" });
     await db.insert({ txt: "abc" });
     await db.insert({ txt: "abcd" });
+    await db.insert({ txt: "abcd" });
+    await db.insert({ txt: "abcd" });
+    await db.insert({ txt: "abcd" });
 
     const search = await db.search({ term: "abc", exact: true });
 
     const id = search.hits[0].id;
     await db.delete(id);
 
-    const search2 = await db.search({ term: "abc" });
+    const search2 = await db.search({ term: "abc", exact: true });
 
+    expect(search2.hits.every(({ id: docID }) => docID !== id)).toBe(true);
     expect(search2.count).toBe(1);
   });
 


### PR DESCRIPTION
This PR would fix #40.

The problem was caused because the `findAllWords` method considered only nodes with `end` as **true**. In this case, the Node would contain other children (with the exact word matched) Lyra will consider only the first node returning the wrong word and comparing it to the term.

I've recycled the `handleOutput` method, that cycles the `docIDs` and adds to the output the document id.

Fixed the false positive.

```bash
> mun@mateounez MINGW64 ~/Development/forks/lyra (main)
$ git checkout main && pnpm just:testing
Already on 'main'
M       package.json
Your branch is up to date with 'origin/main'.

> lyra@1.3.0 just:testing C:\Users\nunmat\Development\forks\lyra
> ts-node ./packages/lyra/just-testing.ts

{ elapsed: '13μs', hits: [], count: 0 }

> mun@mateonunez MINGW64 ~/Development/forks/lyra (main)
$ git checkout fix/trie-exact-match && pnpm just:testing
Switched to branch 'fix/trie-exact-match'
M       package.json
Your branch is up to date with 'origin/fix/trie-exact-match'.

> lyra@1.3.0 just:testing C:\Users\nunmat\Development\forks\lyra
> ts-node ./packages/lyra/just-testing.ts

{
  elapsed: '17μs',
  hits: [
    { id: 'yZFVgKBfe5dqXekBUmuQg', txt: 'abc' },
    { id: '8htoGu6BrItYk0u6c8UgQ', txt: 'abc' }
  ],
  count: 2
}
```