### PR TITLE
Remove by word should consider other doc ids

### DIFF
--- a/packages/lyra/src/prefix-tree/trie.ts
+++ b/packages/lyra/src/prefix-tree/trie.ts
@@ -112,12 +112,12 @@ export class Trie {
     if (!word) return false;
 
     function removeWord(node: TrieNode, _word: string, docID: string): boolean {
-      const [nodeWord /**_docs*/] = node.getWord();
+      const [nodeWord, docIDs] = node.getWord();
 
       if (node.end || (exact && node.end && nodeWord === word)) {
         node.removeDoc(docID);
 
-        if (node.children?.size) {
+        if (node.children?.size && docIDs.has(docID)) {
           node.end = false;
         }
 

--- a/packages/lyra/tests/lyra.test.ts
+++ b/packages/lyra/tests/lyra.test.ts
@@ -235,8 +235,9 @@ describe("lyra", () => {
     const id = search.hits[0].id;
     await db.delete(id);
 
-    const search2 = await db.search({ term: "abc" });
+    const search2 = await db.search({ term: "abc", exact: true });
 
+    expect(search2.hits.every(({ id: docID }) => docID !== id)).toBeTruthy();
     expect(search2.count).toBe(1);
   });
 


### PR DESCRIPTION
This PR would fix #40.

Thanks a lot to @lucaong for supporting me in this bug.

The `removeByWord` now considers if the **docID** exists in _docIDs_ Set, then set the `node.end` as `false`. 
The `exact` param will stay in the function for future implementations.