### PR TITLE
perf: prevent potential overhead on falsy value

### DIFF
--- a/packages/lyra/src/prefix-tree/trie.ts
+++ b/packages/lyra/src/prefix-tree/trie.ts
@@ -90,11 +90,11 @@ export class Trie {
             _output[word] = new Set();
           }
         }
-
-        if (docIDs?.size) {
+        const findResultSet: Set<string> = _output[word];
+        if (docIDs?.size && findResultSet) {
           for (const doc of docIDs) {
-            // check if _output[word] exists and then add the doc to it
-            _output[word] && _output[word].add(doc);
+            // check if findResultSet exists and then add the doc to it
+            findResultSet && findResultSet.add(doc);
           }
         }
       }

--- a/packages/lyra/src/prefix-tree/trie.ts
+++ b/packages/lyra/src/prefix-tree/trie.ts
@@ -94,7 +94,7 @@ export class Trie {
         if (docIDs?.size && findResultSet) {
           for (const doc of docIDs) {
             // check if findResultSet exists and then add the doc to it
-            findResultSet && findResultSet.add(doc);
+            findResultSet.add(doc);
           }
         }
       }


### PR DESCRIPTION
This should prevent unnecessary linear time computations 
(the potential perf improvement is proportional to the docIDs size) 