### PR TITLE
fix: A typo into the generating of README.md file

### DIFF
--- a/packages/benchmarks/benchmark-table/index.mjs
+++ b/packages/benchmarks/benchmark-table/index.mjs
@@ -60,7 +60,7 @@ const table = `
 `;
 
 const markdownContent = `
-# Benchmakrs
+# Benchmarks
 
 The following is an automated benchmark performed on the [Divina Commedia](https://en.wikipedia.org/wiki/Divina_Commedia) dataset. <br />
 You can find the full dataset [here](https://github.com/nearform/lyra/blob/main/packages/benchmarks/dataset/divinaCommedia.json).


### PR DESCRIPTION
fixing the *.mjs file which is responsible of a typo into the packages/benchmark/README.md 
(referring #50 )