### PR TITLE
Style live demo page

### DIFF
--- a/packages/docs/src/components/LyraDemo/index.tsx
+++ b/packages/docs/src/components/LyraDemo/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-// Had to manually import the ESM vestion to satisfy GitHub actions requirements
+// Had to manually import the ESM vesrion to satisfy GitHub actions requirements
 import { create, insert, search, formatNanoseconds } from "@nearform/lyra/dist/esm/lyra";
 import styles from "./style.module.css";
 import dataset from "./events";
@@ -13,7 +13,7 @@ const db = create({
       category2: "string",
     },
     granularity: "string",
-  }
+  },
 });
 
 function formatYear(date: string) {
@@ -65,79 +65,105 @@ export function LyraDemo() {
 
     setMeta({ count, elapsed });
     setResults(hits);
-
   }, [term, limit, offset, exact, tolerance]);
 
   return (
     <>
       <div className={styles.hero}>
         <h1> Try Lyra </h1>
-        <p> Type a search term to perform a full-text search on a dataset of {formatNumber(dataset.result.count)} hystorical events </p>
+        <p>
+          Type a search term to perform a full-text search on a dataset of {formatNumber(dataset.result.count)}{" "}
+          hystorical events
+        </p>
       </div>
 
       <div className={styles.container}>
-        <input
-          type="text"
-          value={term}
-          onChange={e => setTerm(e.target.value)}
-          className={styles.input}
-          placeholder="Type a search term here..."
-        />
+        <div className={styles.inputContainer}>
+          <input
+            type="text"
+            value={term}
+            onChange={e => setTerm(e.target.value)}
+            className={styles.input}
+            placeholder="Type a search term here..."
+          />
+        </div>
 
         <div className={styles.configurations}>
-          <div>
+          <div className={styles.configuration}>
+            <input
+              id="exact"
+              type="checkbox"
+              className={styles.checkbox}
+              checked={exact}
+              onChange={() => setExact(!exact)}
+            />
             <label htmlFor="exact">Exact</label>
-            <input id="exact" type="checkbox" checked={exact} onChange={() => setExact(!exact)} />
           </div>
-          <div>
+          <div className={styles.configuration}>
             <label htmlFor="limit">Limit</label>
-            <input id="limit" type="number" value={limit} onChange={(e) => setLimit(parseInt(e.target.value))} />
+            <input
+              id="limit"
+              type="number"
+              value={limit}
+              className={styles.smallInput}
+              onChange={e => setLimit(parseInt(e.target.value))}
+            />
           </div>
-          <div>
+          <div className={styles.configuration}>
             <label htmlFor="offset">Offset</label>
-            <input id="offset" type="number" value={offset} onChange={(e) => setOffset(parseInt(e.target.value))} />
+            <input
+              className={styles.smallInput}
+              id="offset"
+              type="number"
+              value={offset}
+              onChange={e => setOffset(parseInt(e.target.value))}
+            />
           </div>
-          <div>
+          <div className={styles.configuration}>
             <label htmlFor="tolerance">Typo tolerance</label>
-            <input id="tolerance" type="number" value={tolerance} max={3} min={0} onChange={(e) => setTolerance(parseInt(e.target.value))} />
+            <input
+              id="tolerance"
+              type="number"
+              value={tolerance}
+              className={styles.smallInput}
+              max={3}
+              min={0}
+              onChange={e => setTolerance(parseInt(e.target.value))}
+            />
           </div>
         </div>
 
-        {
-          indexing && (
-            <div className={styles.loading}>
-              <p>Indexing {formatNumber(dataset.result.count)} events...</p>
+        {indexing && (
+          <div className={styles.loading}>
+            <p>Indexing {formatNumber(dataset.result.count)} events...</p>
+          </div>
+        )}
+
+        {!indexing && (
+          <>
+            <div className={styles.meta}>
+              <div>
+                Results: <b>{(meta as any).count}</b>
+              </div>
+              <div>
+                Elapsed: <i>{formatNanoseconds((meta as any).elapsed ?? 0)}</i>
+              </div>
             </div>
-          )
-        }
 
-        {
-          !indexing && (
-            <>
-              <div className={styles.meta}>
-                <div>
-                  Results: {(meta as any).count}
-                </div>
-                <div>
-                  Elapsed: {formatNanoseconds((meta as any).elapsed ?? 0)}
-                </div>
-              </div>
-
-              <div className={styles.overflow}>
-                {
-                  results.map((result, i) => (
-                    <p key={i + result.description} className={styles.resultBox}>
-                      <span className={styles.id}> Year: {formatYear(result.date)} </span>
-                      <span className={styles.id}>{result.categories.category1} ({result.categories.category2}). Granularity: {result.granularity}</span>
-                      <span className={styles.txt}>{result.description}</span>
-                    </p>
-                  ))
-                }
-              </div>
-            </>
-          )
-        }
+            <div className={styles.overflow}>
+              {results.map((result, i) => (
+                <p key={i + result.description} className={styles.resultBox}>
+                  <span className={styles.id}> Year: {formatYear(result.date)} </span>
+                  <span className={styles.id}>
+                    {result.categories.category1} ({result.categories.category2}). Granularity: {result.granularity}
+                  </span>
+                  <span className={styles.txt}>{result.description}</span>
+                </p>
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </>
-  )
+  );
 }

--- a/packages/docs/src/components/LyraDemo/style.module.css
+++ b/packages/docs/src/components/LyraDemo/style.module.css
@@ -25,10 +25,38 @@
   margin: 0;
 }
 
+.inputContainer {
+  margin: 1.3rem auto;
+}
+
 .input {
   width: 100%;
-  margin-bottom: 1rem;
-  padding: 0.5rem;
+  height: 4rem;
+  padding: 0.5rem 1rem;
+  box-shadow: rgba(17, 12, 46, 0.15) 0px 48px 100px 0px;
+  border-radius: 0.5rem;
+  border: solid 1px #e6e6e6;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+
+.smallInput {
+  width: 5rem;
+  height: 3rem;
+  padding: 0.5rem 1rem;
+  box-shadow: rgba(17, 12, 46, 0.15) 0px 48px 100px 0px;
+  border-radius: 0.5rem;
+  border: solid 1px #e6e6e6;
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.checkbox {
+  width: 24px;
+  height: 24px;
+  border-radius: 2rem;
+  border: solid 1px #e6e6e6;
+  margin-right: 1rem;
 }
 
 .overflow {
@@ -68,13 +96,37 @@
 }
 
 .configurations {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
   width: 100%;
+  margin: auto;
+}
+
+.configuration label {
+  font-weight: bold;
+  margin-right: 1rem;
+}
+
+.configuration {
+  width: 100%;
+  display: flex;
+  align-items: center;
   margin-bottom: 1rem;
 }
 
-.configurations label {
-  font-weight: bold;
-  margin-right: 1rem;
+@media (max-width: 900px) {
+  .configurations {
+    flex-direction: column;
+  }
+
+  .configuration {
+    width: 100%;
+    display: flex;
+    align-items: center;
+  }
+
+  .configuration label {
+    width: 8rem;
+  }
 }


### PR DESCRIPTION
This PR would improve the current design of `Live Demo` page.

This is how looks:

![image](https://user-images.githubusercontent.com/11861080/182604655-3923934a-f8bd-4efe-96d5-dbbad54801ae.png)

It's really simple and clean. I'm considering creating a more dynamic page adding the DB structure and searching by schema properties with a different design. 

**Mobile**

![image](https://user-images.githubusercontent.com/11861080/182604804-e3bd071e-ea25-4731-b6ba-332e5ba7d7e5.png)
