### PR TITLE
refactor: fix some minor linter warnings

### DIFF
--- a/packages/development-repl/repl.ts
+++ b/packages/development-repl/repl.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as readline from "node:readline";
 import * as util from "node:util";
-import { create, insert, search, SearchParams } from "@nearform/lyra";
+import { create, insert, search, PropertiesSchema, SearchParams } from "@nearform/lyra";
 import yargs from "yargs";
 import progress from "cli-progress";
 
@@ -97,7 +97,7 @@ rl.on("line", async (cmd: string) => {
     offset: parsed.offset ?? 0,
     exact: parsed.exact,
     tolerance: parsed.tolerance ?? 0,
-  } as SearchParams<unknown>);
+  } as SearchParams<PropertiesSchema>);
 
   log(searchResult);
 });

--- a/packages/development-repl/repl.ts
+++ b/packages/development-repl/repl.ts
@@ -97,7 +97,7 @@ rl.on("line", async (cmd: string) => {
     offset: parsed.offset ?? 0,
     exact: parsed.exact,
     tolerance: parsed.tolerance ?? 0,
-  } as unknown as SearchParams<any>);
+  } as SearchParams<unknown>);
 
-  log(searchResult as any);
+  log(searchResult);
 });

--- a/packages/lyra/tests/lyra.dataset.test.ts
+++ b/packages/lyra/tests/lyra.dataset.test.ts
@@ -1,8 +1,9 @@
 import t from "tap";
-import { create, insert, remove, search, SearchResult } from "../src/lyra";
+import { create, insert, remove, search } from "../src/lyra";
+import type { PropertiesSchema, SearchResult } from "../src/lyra";
 import dataset from "./datasets/events.json";
 
-function removeVariadicData(res: SearchResult<any>): SearchResult<any> {
+function removeVariadicData(res: SearchResult<PropertiesSchema>): SearchResult<PropertiesSchema> {
   const hits = res.hits.map(h => {
     h.id = "";
     return h;

--- a/packages/lyra/tests/lyra.dataset.test.ts
+++ b/packages/lyra/tests/lyra.dataset.test.ts
@@ -3,7 +3,7 @@ import { create, insert, remove, search } from "../src/lyra";
 import type { PropertiesSchema, SearchResult } from "../src/lyra";
 import dataset from "./datasets/events.json";
 
-function removeVariadicData(res: SearchResult<PropertiesSchema>): SearchResult<PropertiesSchema> {
+function removeVariadicData<T extends PropertiesSchema>(res: SearchResult<T>): SearchResult<T> {
   const hits = res.hits.map(h => {
     h.id = "";
     return h;


### PR DESCRIPTION
**EDIT:** Now I'm not so sure if it's a good idea to propose these changes, as `repl.ts` seems to be kinda "out of reach" for the type checker, and I might be introducing some difficult-to-detect problems until that is solved in the first place.

The changes of this PR are merely cosmetic, but I find it a good thing to have a smaller amount of warnings when we run the linter :) .